### PR TITLE
re-erase the `Ctxt`

### DIFF
--- a/SSA/Experimental/ErasedContext.lean
+++ b/SSA/Experimental/ErasedContext.lean
@@ -49,6 +49,11 @@ theorem get?_snoc_succ {Γ : Ctxt Ty} {t : Ty} {n : Nat} :
     (Γ.snoc t).get? (n + 1) = Γ.get? n := by
   simp [snoc]
 
+@[simp]
+theorem get?_snoc_zero {Γ : Ctxt Ty} {t : Ty} :
+    (Γ.snoc t).get? 0 = t := by
+  simp [snoc]
+
   
 
 def Var (Γ : Ctxt Ty) (t : Ty) : Type :=

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -591,6 +591,11 @@ theorem subset_entries_matchVar_matchArg_aux
       (subset_entries_matchVar_matchArg_aux hmatchVar h₂)
     exact hmatchVar _ _ _ _ _ h₁
 
+
+@[injection]
+theorem Ctxt.snoc_inj (h : Ctxt.snoc Γ₁ t₁ = Ctxt.snoc Γ₂ t₂ ) : Γ₁ = Γ₂ ∧ t₁ = t₂ := by
+  sorry
+
 /-- The output mapping of `matchVar` extends the input mapping when it succeeds. -/
 theorem subset_entries_matchVar [DecidableEq Op]
     {varMap : Mapping Δ_in Γ_out} {ma : Mapping Δ_in Γ_out}
@@ -718,7 +723,10 @@ theorem denote_matchVar_of_subset
     apply denote_matchVar_of_subset
   | .lete matchLets matchExpr, ⟨0, h_w⟩ => by
     rename_i t'
-    have : t = t' := by simp[List.get?] at h_w; apply h_w.symm
+    have : t = t' := by 
+      simp only [Ctxt.get?_snoc_zero] at h_w; 
+      injection h_w with h_w
+      apply h_w.symm
     subst this
     simp [matchVar, Bind.bind, Option.bind]
     intro h_sub h_mv
@@ -1010,6 +1018,7 @@ instance {Γ : List Ty} {t' : Ty} {lhs : ICom Op (.ofList Γ) t'} :
     rcases List.get?_eq_some.1 hi with ⟨h', rfl⟩
     simp at h'
     convert h ⟨i, h'⟩
+    simp only [Ctxt.ofList, Erased.out_mk]
   . intro h i
     apply h
 

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -1107,7 +1107,7 @@ macro "simp_peephole": tactic =>
       (
       funext ll
       simp only [ICom.denote, IExpr.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
-        Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc, add,
+        Ctxt.snoc, Ctxt.ofList, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc, add,
         cst, HVector.map, OpDenote.denote, IExpr.op_mk, IExpr.args_mk]
       generalize ll { val := 0, property := _ } = a;
       generalize ll { val := 1, property := _ } = b;
@@ -1157,17 +1157,7 @@ def p1 : PeepholeRewrite ExOp [.nat, .nat] .nat:=
   { lhs := m, rhs := r, correct :=
     by
       rw [m, r]
-      -- simp_peephole
-      funext ll
-      simp only [ICom.denote, IExpr.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
-        Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc, add,
-        cst, HVector.map, OpDenote.denote, IExpr.op_mk, IExpr.args_mk]
-      generalize ll { val := 0, property := _ } = a;
-      generalize ll { val := 1, property := _ } = b;
-      simp [Goedel.toType] at a b;
-      -- rw [Ctxt.Valuation.snoc_last]
-      rw [@Ctxt.Valuation.snoc_last _ _ (Erased.mk [ExTy.nat, ExTy.nat])]
-      rw [@Ctxt.Valuation.snoc_last _ _ (Erased.mk [ExTy.nat, ExTy.nat])]
+      simp_peephole
       intros a b
       rw [Nat.add_comm]
     }

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -1128,7 +1128,7 @@ macro "simp_peephole": tactic =>
       try revert c;
       try revert b;
       try revert a;
-      try clear ll;
+      clear ll;
       )
    )
 

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -1128,7 +1128,7 @@ macro "simp_peephole": tactic =>
       try revert c;
       try revert b;
       try revert a;
-      clear ll;
+      try clear ll;
       )
    )
 
@@ -1157,7 +1157,17 @@ def p1 : PeepholeRewrite ExOp [.nat, .nat] .nat:=
   { lhs := m, rhs := r, correct :=
     by
       rw [m, r]
-      simp_peephole
+      -- simp_peephole
+      funext ll
+      simp only [ICom.denote, IExpr.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
+        Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc, add,
+        cst, HVector.map, OpDenote.denote, IExpr.op_mk, IExpr.args_mk]
+      generalize ll { val := 0, property := _ } = a;
+      generalize ll { val := 1, property := _ } = b;
+      simp [Goedel.toType] at a b;
+      -- rw [Ctxt.Valuation.snoc_last]
+      rw [@Ctxt.Valuation.snoc_last _ _ (Erased.mk [ExTy.nat, ExTy.nat])]
+      rw [@Ctxt.Valuation.snoc_last _ _ (Erased.mk [ExTy.nat, ExTy.nat])]
       intros a b
       rw [Nat.add_comm]
     }

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -12,7 +12,7 @@
   {"git":
    {"url": "https://github.com/mhuisi/lean4-cli.git",
     "subDir?": null,
-    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
+    "rev": "21dac2e9cc7e3cf7da5800814787b833e680b2fd",
     "opts": {},
     "name": "Cli",
     "inputRev?": "nightly",
@@ -20,15 +20,15 @@
   {"git":
    {"url": "https://github.com/leanprover-community/mathlib4",
     "subDir?": null,
-    "rev": "891adb329938ca3cd49a1d1208f691a98fb0896f",
+    "rev": "bd93b8ebdaea3189c903b6b2af47645a952ea5e5",
     "opts": {},
     "name": "mathlib",
-    "inputRev?": "891adb3",
+    "inputRev?": "bd93b8e",
     "inherited": false}},
   {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "81cc13c524a68d0072561dbac276cd61b65872a6",
+    "rev": "e75daed95ad1c92af4e577fea95e234d7a8401c1",
     "opts": {},
     "name": "Qq",
     "inputRev?": "master",
@@ -36,7 +36,7 @@
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "086c98bb129ca856381d4414dc0afd6e3e4ae2ef",
+    "rev": "1a0cded2be292b5496e659b730d2accc742de098",
     "opts": {},
     "name": "aesop",
     "inputRev?": "master",
@@ -44,7 +44,7 @@
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "b5f7bd40d2162fe148e585543f284a5d8cc0ef26",
+    "rev": "ba5e5e3af519b4fc5221ad0fa4b2c87276f1d323",
     "opts": {},
     "name": "std",
     "inputRev?": "main",

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -37,7 +37,7 @@ lean_exe mlirnatural {
 
 -- NOTE: this must be 'm'mathlib, as indicated from:
 --  https://github.com/leanprover-community/mathlib4#using-mathlib4-as-a-dependency
-require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "891adb3"
+require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "bd93b8e"
 
 require Cli from git "https://github.com/mhuisi/lean4-cli.git" @ "nightly"
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,2 +1,1 @@
-leanprover/lean4:nightly-2023-08-23
-
+alexkeizer/lean4:extensible-injection


### PR DESCRIPTION
At some point, we changed `Ctxt` to be just a `List`. We moved away from the reason behind this change,
so we can move back to erased contexts