### PR TITLE
feat: add example op that uses region: runK

### DIFF
--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -1070,10 +1070,8 @@ instance : OpSignature ExOp ExTy where
     | .add => [.nat, .nat]
     | .beq => [.nat, .nat]
     | .cst _ => []
-  regSig
-   | _ => []
+  regSig := fun _ => []
 
--- (bollu:) unknown free variable: _kernel_fresh.104
 @[reducible]
 instance : OpDenote ExOp ExTy where
   denote

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -1070,18 +1070,18 @@ instance : OpSignature ExOp ExTy where
     | .add => [.nat, .nat]
     | .beq => [.nat, .nat]
     | .cst _ => []
-  regSig 
+  regSig
    | _ => []
-  
+
 /-- Compose `f` with itself `n` times -/
-def loopN (f : α → α) (n : ℕ) (x: α) : α := 
+def loopN (f : α → α) (n : ℕ) (x: α) : α :=
   match n with
   | 0 => x
   | n' + 1 => loopN f n' (f x)
 
 theorem loopN_zero_id : loopN f 0 x = x := by simp[loopN]
 
-theorem loopN_succ_unfold_right: loopN f (m + 1) x = loopN f m (f x) := rfl 
+theorem loopN_succ_unfold_right: loopN f (m + 1) x = loopN f m (f x) := rfl
 
 theorem loopN_succ_unfold_left: loopN f (m + 1) x = f (loopN f m x) := by {
   revert x;
@@ -1097,8 +1097,8 @@ theorem loopN_succ_unfold_left: loopN f (m + 1) x = f (loopN f m x) := by {
 }
 
 
-theorem loopN_monoid_hom: loopN f m (loopN f n x) = loopN f (m + n) x := by 
-  sorry 
+theorem loopN_monoid_hom: loopN f m (loopN f n x) = loopN f (m + n) x := by
+  sorry
 
 -- (bollu:) unknown free variable: _kernel_fresh.104
 @[reducible]
@@ -1107,8 +1107,8 @@ instance : OpDenote ExOp ExTy where
     | .cst n, _, _ => n
     | .add, .cons (a : Nat) (.cons b .nil), _ => a + b
     | .beq, .cons (a : Nat) (.cons b .nil), _ => a == b
---  | .runK (k : Nat), (.cons (v : Nat) .nil), (.cons rgn nil) => 
---       loopN (coe_ctxt_nat2nat_to_fun rgn) k v 
+--  | .runK (k : Nat), (.cons (v : Nat) .nil), (.cons rgn nil) =>
+--       loopN (coe_ctxt_nat2nat_to_fun rgn) k v
 
 def cst {Γ : Ctxt _} (n : ℕ) : IExpr ExOp Γ .nat  :=
   IExpr.mk
@@ -1390,7 +1390,7 @@ example : rewritePeepholeAt p4 5 ex3 = (
 
 end Examples
 
-namespace RegionExamples 
+namespace RegionExamples
 
 /-- A very simple type universe. -/
 inductive ExTy
@@ -1418,11 +1418,11 @@ instance : OpSignature ExOp ExTy where
     -- | .cst _ => []
     | .runK _ => [.nat]
   regSig
-   | .runK _ => [([.nat], .nat)] 
+   | .runK _ => [([.nat], .nat)]
    | _ => []
 
 /-- Compose `f` with itself `n` times -/
-def loopN (f : α → α) (n : ℕ) (x: α) : α := 
+def loopN (f : α → α) (n : ℕ) (x: α) : α :=
   match n with
   | 0 => x
   | n' + 1 => loopN f n' (f x)
@@ -1431,8 +1431,8 @@ def loopN (f : α → α) (n : ℕ) (x: α) : α :=
 instance : OpDenote ExOp ExTy where
   denote
     | .add, .cons (a : Nat) (.cons b .nil), _ => a + b
-    | .runK (k : Nat), (.cons (v : Nat) .nil), (.cons rgn _nil) => 
-      loopN (n := k) (fun val => rgn (fun _ty _var => val)) v 
+    | .runK (k : Nat), (.cons (v : Nat) .nil), (.cons rgn _nil) =>
+      loopN (n := k) (fun val => rgn (fun _ty _var => val)) v
 
 @[simp]
 def add {Γ : Ctxt _} (e₁ e₂ : Var Γ .nat) : IExpr ExOp Γ .nat :=
@@ -1442,7 +1442,7 @@ def add {Γ : Ctxt _} (e₁ e₂ : Var Γ .nat) : IExpr ExOp Γ .nat :=
     (args := .cons e₁ <| .cons e₂ .nil)
     (regArgs := .nil)
 @[simp]
-def rgn {Γ : Ctxt _} (k : Nat) (input : Var Γ .nat) (body : ICom ExOp [ExTy.nat] ExTy.nat) : IExpr ExOp Γ .nat := 
+def rgn {Γ : Ctxt _} (k : Nat) (input : Var Γ .nat) (body : ICom ExOp [ExTy.nat] ExTy.nat) : IExpr ExOp Γ .nat :=
   IExpr.mk
     (op := .runK k)
     (ty_eq := rfl)
@@ -1481,11 +1481,11 @@ macro "simp_peephole": tactic =>
 
 attribute [local simp] Ctxt.snoc
 
--- running `f(x) = x + x` 0 times is the identity.
+/-- running `f(x) = x + x` 0 times is the identity. -/
 def ex1_lhs : ICom ExOp [.nat] .nat :=
   ICom.lete (rgn (k := 0) ⟨0, by simp[Ctxt.snoc]⟩ (
-      ICom.lete (add ⟨0, by simp[Ctxt.snoc]⟩ ⟨0, by simp[Ctxt.snoc]⟩) -- fun x => (x + x) 
-      <| ICom.ret ⟨0, by simp[Ctxt.snoc]⟩ 
+      ICom.lete (add ⟨0, by simp[Ctxt.snoc]⟩ ⟨0, by simp[Ctxt.snoc]⟩) -- fun x => (x + x)
+      <| ICom.ret ⟨0, by simp[Ctxt.snoc]⟩
   )) <|
   ICom.ret ⟨0, by simp[Ctxt.snoc]⟩
 
@@ -1504,18 +1504,17 @@ def p1 : PeepholeRewrite ExOp [.nat] .nat:=
     }
 
 
-
--- running `f(x) = x + x` 1 times does return `x + x`.
+/-- running `f(x) = x + x` 1 times does return `x + x`. -/
 def ex2_lhs : ICom ExOp [.nat] .nat :=
-  ICom.lete (rgn (k := 0) ⟨0, by simp[Ctxt.snoc]⟩ (
-      ICom.lete (add ⟨0, by simp[Ctxt.snoc]⟩ ⟨0, by simp[Ctxt.snoc]⟩) -- fun x => (x + x) 
-      <| ICom.ret ⟨0, by simp[Ctxt.snoc]⟩ 
+  ICom.lete (rgn (k := 1) ⟨0, by simp[Ctxt.snoc]⟩ (
+      ICom.lete (add ⟨0, by simp[Ctxt.snoc]⟩ ⟨0, by simp[Ctxt.snoc]⟩) -- fun x => (x + x)
+      <| ICom.ret ⟨0, by simp[Ctxt.snoc]⟩
   )) <|
   ICom.ret ⟨0, by simp[Ctxt.snoc]⟩
 
 def ex2_rhs : ICom ExOp [.nat] .nat :=
-    ICom.lete (add ⟨0, by simp[Ctxt.snoc]⟩ ⟨0, by simp[Ctxt.snoc]⟩) -- fun x => (x + x) 
-    <| ICom.ret ⟨0, by simp[Ctxt.snoc]⟩ 
+    ICom.lete (add ⟨0, by simp[Ctxt.snoc]⟩ ⟨0, by simp[Ctxt.snoc]⟩) -- fun x => (x + x)
+    <| ICom.ret ⟨0, by simp[Ctxt.snoc]⟩
 
 def p2 : PeepholeRewrite ExOp [.nat] .nat:=
   { lhs := ex2_lhs, rhs := ex2_rhs, correct :=
@@ -1525,7 +1524,7 @@ def p2 : PeepholeRewrite ExOp [.nat] .nat:=
       simp [ICom.denote, IExpr.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
         Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc, add,
         rgn, HVector.map, OpDenote.denote, IExpr.op_mk, IExpr.args_mk, HVector.denote];
-      sorry -- what did I get wrong?
+      simp[loopN];
     }
 
-end RegionExamples 
+end RegionExamples

--- a/SSA/Experimental/IntrinsicAsymptotics.lean
+++ b/SSA/Experimental/IntrinsicAsymptotics.lean
@@ -132,6 +132,23 @@ termination_by
   ICom.denote _ _ e _ => sizeOf e
   HVector.denote _ _ e => sizeOf e
 
+/-
+https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Equational.20Lemmas
+Recall that `simp` lazily generates equation lemmas.
+Moreover, recall that `simp only` **does not** generate equation lemmas.
+*but* if equation lemmas are present, then `simp only` *uses* the equation lemmas.
+
+Hence, we build the equation lemmas by invoking the correct Lean meta magic,
+so that `simp only` (which we use in `simp_peephole` can find them!)
+
+This allows `simp only [HVector.denote]` to correctly simplify `HVector.denote`
+args, since there now are equation lemmas for it.
+-/
+#eval Lean.Meta.getEqnsFor? ``HVector.denote
+#eval Lean.Meta.getEqnsFor? ``IExpr.denote
+#eval Lean.Meta.getEqnsFor? ``ICom.denote
+
+
 def Lets.denote : Lets Op Γ₁ Γ₂ → Γ₁.Valuation → Γ₂.Valuation
   | .nil => id
   | .lete e body => fun ll t v => by
@@ -1035,6 +1052,47 @@ theorem denote_rewritePeepholeAt (pr : PeepholeRewrite Op Γ t)
         | none => simp
     case neg h => simp
 
+section SimpPeephole
+
+
+/--
+Simplify evaluation junk, leaving behind Lean level proposition to be proven.
+-/
+macro "simp_peephole" "[" ts: Lean.Parser.Tactic.simpLemma,* "]" : tactic =>
+  `(tactic|
+      (
+      funext ll
+      simp only [ICom.denote, IExpr.denote, HVector.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
+        Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
+        HVector.map, OpDenote.denote, IExpr.op_mk, IExpr.args_mk, $ts,*]
+      generalize ll { val := 0, property := _ } = a;
+      generalize ll { val := 1, property := _ } = b;
+      generalize ll { val := 2, property := _ } = c;
+      generalize ll { val := 3, property := _ } = d;
+      generalize ll { val := 4, property := _ } = e;
+      generalize ll { val := 5, property := _ } = f;
+      simp [Goedel.toType] at a b c d e f;
+      try clear f;
+      try clear e;
+      try clear d;
+      try clear c;
+      try clear b;
+      try clear a;
+      try revert f;
+      try revert e;
+      try revert d;
+      try revert c;
+      try revert b;
+      try revert a;
+      try clear ll;
+      )
+   )
+
+/-- `simp_peephole` with no extra user defined theorems. -/
+macro "simp_peephole" : tactic => `(tactic| simp_peephole [])
+
+
+end SimpPeephole
 
 
 /-
@@ -1093,36 +1151,6 @@ def add {Γ : Ctxt _} (e₁ e₂ : Var Γ .nat) : IExpr ExOp Γ .nat :=
     (args := .cons e₁ <| .cons e₂ .nil)
     (regArgs := .nil)
 
-macro "simp_peephole": tactic =>
-  `(tactic|
-      (
-      funext ll
-      simp only [ICom.denote, IExpr.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
-        Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc, add,
-        cst, HVector.map, OpDenote.denote, IExpr.op_mk, IExpr.args_mk]
-      generalize ll { val := 0, property := _ } = a;
-      generalize ll { val := 1, property := _ } = b;
-      generalize ll { val := 2, property := _ } = c;
-      generalize ll { val := 3, property := _ } = d;
-      generalize ll { val := 4, property := _ } = e;
-      generalize ll { val := 5, property := _ } = f;
-      simp [Goedel.toType] at a b c d e f;
-      try clear f;
-      try clear e;
-      try clear d;
-      try clear c;
-      try clear b;
-      try clear a;
-      try revert f;
-      try revert e;
-      try revert d;
-      try revert c;
-      try revert b;
-      try revert a;
-      clear ll;
-      )
-   )
-
 attribute [local simp] Ctxt.snoc
 
 def ex1 : ICom ExOp ∅ .nat :=
@@ -1148,7 +1176,7 @@ def p1 : PeepholeRewrite ExOp [.nat, .nat] .nat:=
   { lhs := m, rhs := r, correct :=
     by
       rw [m, r]
-      simp_peephole
+      simp_peephole [add, cst]
       intros a b
       rw [Nat.add_comm]
     }
@@ -1217,7 +1245,7 @@ def p2 : PeepholeRewrite ExOp [.nat, .nat] .nat:=
   { lhs := m, rhs := r2, correct :=
     by
       rw [m, r2]
-      simp_peephole
+      simp_peephole [add, cst]
       intros a b
       rw [Nat.zero_add]
       rw [Nat.add_comm]
@@ -1278,7 +1306,7 @@ def p3 : PeepholeRewrite ExOp [.nat, .nat] .nat:=
   { lhs := m, rhs := r3, correct :=
     by
       rw [m, r3]
-      simp_peephole
+      simp_peephole [add, cst]
       intros a b
       rw [Nat.zero_add]
     }
@@ -1341,7 +1369,7 @@ def p4 : PeepholeRewrite ExOp [.nat, .nat] .nat:=
   { lhs := r3, rhs := m, correct :=
     by
       rw [m, r3]
-      simp_peephole
+      simp_peephole [add, cst]
       intros a b
       rw [Nat.zero_add]
     }
@@ -1384,25 +1412,17 @@ instance : OpSignature ExOp ExTy where
     | .add => [.nat, .nat]
     | .runK _ => [.nat]
   regSig
-   | .runK _ => [([.nat], .nat)]
-   | _ => []
+    | .runK _ => [([.nat], .nat)]
+    | _ => []
 
-/-- Compose `f` with itself `n` times.
-  @chris: What's the mathlib correct version of this?
- -/
-def loopN (f : α → α) (n : ℕ) (x: α) : α :=
-  match n with
-  | 0 => x
-  | n' + 1 => loopN f n' (f x)
 
 @[reducible]
 instance : OpDenote ExOp ExTy where
   denote
     | .add, .cons (a : Nat) (.cons b .nil), _ => a + b
     | .runK (k : Nat), (.cons (v : Nat) .nil), (.cons rgn _nil) =>
-      loopN (n := k) (fun val => rgn (fun _ty _var => val)) v
+      k.iterate (fun val => rgn (fun _ty _var => val)) v
 
-@[simp]
 def add {Γ : Ctxt _} (e₁ e₂ : Var Γ .nat) : IExpr ExOp Γ .nat :=
   IExpr.mk
     (op := .add)
@@ -1410,43 +1430,12 @@ def add {Γ : Ctxt _} (e₁ e₂ : Var Γ .nat) : IExpr ExOp Γ .nat :=
     (args := .cons e₁ <| .cons e₂ .nil)
     (regArgs := .nil)
 
-@[simp]
 def rgn {Γ : Ctxt _} (k : Nat) (input : Var Γ .nat) (body : ICom ExOp [ExTy.nat] ExTy.nat) : IExpr ExOp Γ .nat :=
   IExpr.mk
     (op := .runK k)
     (ty_eq := rfl)
     (args := .cons input .nil)
     (regArgs := HVector.cons body HVector.nil)
-
-macro "simp_peephole": tactic =>
-  `(tactic|
-      (
-      funext ll
-      simp only [ICom.denote, IExpr.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
-        Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc, add,
-        rgn, loopN,HVector.map, OpDenote.denote, IExpr.op_mk, IExpr.args_mk]
-      generalize ll { val := 0, property := _ } = a;
-      generalize ll { val := 1, property := _ } = b;
-      generalize ll { val := 2, property := _ } = c;
-      generalize ll { val := 3, property := _ } = d;
-      generalize ll { val := 4, property := _ } = e;
-      generalize ll { val := 5, property := _ } = f;
-      simp [Goedel.toType] at a b c d e f;
-      try clear f;
-      try clear e;
-      try clear d;
-      try clear c;
-      try clear b;
-      try clear a;
-      try revert f;
-      try revert e;
-      try revert d;
-      try revert c;
-      try revert b;
-      try revert a;
-      clear ll;
-      )
-   )
 
 attribute [local simp] Ctxt.snoc
 
@@ -1462,16 +1451,12 @@ def ex1_rhs : ICom ExOp [.nat] .nat :=
   ICom.ret ⟨0, by simp[Ctxt.snoc]⟩
 
 def p1 : PeepholeRewrite ExOp [.nat] .nat:=
-  { lhs := ex1_lhs, rhs := ex1_rhs, correct :=
-    by
+  { lhs := ex1_lhs, rhs := ex1_rhs, correct := by
       rw [ex1_lhs, ex1_rhs]
-      funext ll
-      simp [ICom.denote, IExpr.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
-        Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc, add,
-        rgn, HVector.map, OpDenote.denote, IExpr.op_mk, IExpr.args_mk, HVector.denote]
-      simp[loopN]
-    }
-
+      simp_peephole [add, rgn]
+      simp
+      done
+  }
 
 /-- running `f(x) = x + x` 1 times does return `x + x`. -/
 def ex2_lhs : ICom ExOp [.nat] .nat :=
@@ -1486,14 +1471,11 @@ def ex2_rhs : ICom ExOp [.nat] .nat :=
     <| ICom.ret ⟨0, by simp[Ctxt.snoc]⟩
 
 def p2 : PeepholeRewrite ExOp [.nat] .nat:=
-  { lhs := ex2_lhs, rhs := ex2_rhs, correct :=
-    by
+  { lhs := ex2_lhs, rhs := ex2_rhs, correct := by
       rw [ex2_lhs, ex2_rhs]
-      funext ll
-      simp [ICom.denote, IExpr.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
-        Ctxt.snoc, Ctxt.Valuation.snoc_last, Ctxt.Valuation.snoc_toSnoc, add,
-        rgn, HVector.map, OpDenote.denote, IExpr.op_mk, IExpr.args_mk, HVector.denote]
-      simp[loopN]
-    }
+      simp_peephole[add, rgn]
+      simp
+      done
+  }
 
 end RegionExamples


### PR DESCRIPTION
In adding this example, I seem to have run into a Lean bug:

```lean
-- (bollu:) unknown free variable: _kernel_fresh.104
@[reducible]
instance : OpDenote ExOp ExTy where
  denote
    | .cst n, _, _ => n
    | .add, .cons (a : Nat) (.cons b .nil), _ => a + b
    | .beq, .cons (a : Nat) (.cons b .nil), _ => a == b
    | .runK (k : Nat), _, _ => (0 : Nat)
```