### PR TITLE
Port Tensor1D to new framework

### DIFF
--- a/SSA.lean
+++ b/SSA.lean
@@ -8,8 +8,8 @@ import SSA.Core.Framework
 
 -- Eventually, all projects must be imported.
 import SSA.Projects.InstCombine.Alive
--- import SSA.Projects.Tensor1D.Tensor1D
--- import SSA.Projects.Tensor2D.Tensor2D
+import SSA.Projects.Tensor1D.Tensor1D
+import SSA.Projects.Tensor2D.Tensor2D
 
 
 -- EXPERIMENTAL

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Erased
 import Mathlib.Data.Finset.Basic
+import SSA.Core.HVector
 
 /-- 
   Typeclass for a `baseType` which is a Gödel code of Lean types.
@@ -197,6 +198,11 @@ theorem Valuation.snoc_last {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toTy
 theorem Valuation.snoc_toSnoc {Γ : Ctxt Ty} {t t' : Ty} (s : Γ.Valuation) (x : toType t)
     (v : Γ.Var t') : (s.snoc x) v.toSnoc = s v := by
   simp [Ctxt.Valuation.snoc]
+
+/-- Build valuation from a list of values of types `types`. -/
+def Valuation.ofList {types : List Ty} : HVector toType types → Valuation (Ctxt.ofList types)
+  | .nil => (default : Ctxt.Valuation (∅ : Ctxt Ty))
+  | .cons x xs => (Valuation.ofList xs).snoc x
 
 end Valuation
 

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -199,10 +199,10 @@ theorem Valuation.snoc_toSnoc {Γ : Ctxt Ty} {t t' : Ty} (s : Γ.Valuation) (x :
     (v : Γ.Var t') : (s.snoc x) v.toSnoc = s v := by
   simp [Ctxt.Valuation.snoc]
 
-/-- Build valuation from a list of values of types `types`. -/
-def Valuation.ofList {types : List Ty} : HVector toType types → Valuation (Ctxt.ofList types)
+/-- Build valuation from a vector of values of types `types`. -/
+def Valuation.ofHVector {types : List Ty} : HVector toType types → Valuation (Ctxt.ofList types)
   | .nil => (default : Ctxt.Valuation (∅ : Ctxt Ty))
-  | .cons x xs => (Valuation.ofList xs).snoc x
+  | .cons x xs => (Valuation.ofHVector xs).snoc x
 
 end Valuation
 

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -1,5 +1,5 @@
 --import SSA.Core.WellTypedFramework
-import SSA.Core.Framework
+import SSA.Experimental.IntrinsicAsymptotics
 import SSA.Core.Util
 import SSA.Projects.InstCombine.ForMathlib
 

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -1,5 +1,5 @@
 --import SSA.Core.WellTypedFramework
-import SSA.Experimental.IntrinsicAsymptotics
+import SSA.Core.Framework
 import SSA.Core.Util
 import SSA.Projects.InstCombine.ForMathlib
 

--- a/SSA/Projects/Tensor1D/Tensor1D.lean
+++ b/SSA/Projects/Tensor1D/Tensor1D.lean
@@ -315,17 +315,17 @@ This matches the MLIR model, which has a separate `index` type for indexing
 and `iXX/f32/f64` types for values held in tensors.
 -/
 inductive ExOp
-| add
-| const (v: Index)
-| sub
-| map1d
-| extract1d
+| /-- add two integers -/ add
+| /-- create a constant index -/ const (v: Index)
+| /-- subtract two integers -/ sub
+| /-- map a function onto a tensor -/ map1d
+| /-- extract a value at an index of a tensor -/ extract1d
 deriving DecidableEq
 
 inductive ExTy
-| int : ExTy -- values held in tensors
-| ix : ExTy -- indexing into tensors.
-| tensor1d  : ExTy -- tensor type.
+| /-- values held in tensors -/ int : ExTy 
+| /-- shapes and indexes of tensors -/ ix : ExTy
+| /-- tensor type -/ tensor1d  : ExTy
 deriving DecidableEq, Inhabited
 
 instance : Goedel ExTy where
@@ -347,7 +347,7 @@ instance : OpSignature ExOp ExTy where
   | .map1d => [.tensor1d]
   | .extract1d => [.tensor1d, .ix, .ix]
   | .const _ => []
-  
+
   regSig
   | .map1d => [([.int], .int)]
   | _ => []

--- a/SSA/Projects/Tensor1D/Tensor1D.lean
+++ b/SSA/Projects/Tensor1D/Tensor1D.lean
@@ -311,9 +311,9 @@ This matches the MLIR model, which has a separate `index` type for indexing
 and `iXX/f32/f64` types for values held in tensors.
 -/
 inductive ExOp
-| /-- add two integers -/ add
-| /-- create a constant index -/ const (v: Index)
-| /-- subtract two integers -/ sub
+| /-- add two integers -/ add_int
+| /-- create a constant index -/ const_ix (v: Index)
+| /-- subtract two integers -/ sub_int
 | /-- map a function onto a tensor -/ map1d
 | /-- extract a value at an index of a tensor -/ extract1d
 deriving DecidableEq
@@ -332,17 +332,17 @@ instance : Goedel ExTy where
 
 instance : OpSignature ExOp ExTy where
   outTy : ExOp → ExTy
-  | .add => .int
-  | .sub => .int
-  | .const _ => .ix
+  | .add_int => .int
+  | .sub_int => .int
+  | .const_ix _ => .ix
   | .map1d =>  .tensor1d
   | .extract1d =>  .tensor1d
   sig  : ExOp → List ExTy
-  | .add => [.int, .int]
-  | .sub => [.int, .int]
+  | .add_int => [.int, .int]
+  | .sub_int => [.int, .int]
   | .map1d => [.tensor1d]
   | .extract1d => [.tensor1d, .ix, .ix]
-  | .const _ => []
+  | .const_ix _ => []
 
   regSig
   | .map1d => [([.int], .int)]
@@ -353,12 +353,12 @@ instance : OpSignature ExOp ExTy where
 @[reducible]
 instance : OpDenote ExOp ExTy where
   denote
-  | .const v, _, _ => v
-  | .add, (.cons x (.cons y nil)), _ =>
+  | .const_ix v, _, _ => v
+  | .add_int, (.cons x (.cons y nil)), _ =>
       let x : Int := x;
       let y : Int := y
       x + y
-  | .sub, (.cons x (.cons y nil)), _ =>
+  | .sub_int, (.cons x (.cons y nil)), _ =>
     let x : Int := x;
     let y : Int := y;
     x - y
@@ -374,7 +374,6 @@ instance : OpDenote ExOp ExTy where
     let len : Index := len;
     t.extract l len
 -/
-
 /-
 open SSA EDSL in
 theorem extract_map (r0 : TSSA Op Context.empty _) :

--- a/SSA/Projects/Tensor1D/Tensor1D.lean
+++ b/SSA/Projects/Tensor1D/Tensor1D.lean
@@ -365,7 +365,7 @@ instance : OpDenote Op Ty where
   | .map1d, (.cons t .nil), (.cons r .nil) =>
     let t : Tensor1d Int := t;
     -- Is there a cleaner way to build the data below?
-    let r : Int → Int := fun v =>  r (Ctxt.Valuation.ofList <| (.cons v .nil))
+    let r : Int → Int := fun v =>  r (Ctxt.Valuation.ofHVector <| (.cons v .nil))
     let t' := t.map r
     t'
   | .extract1d, (.cons t (.cons l (.cons len .nil))), _ =>

--- a/SSA/Projects/Tensor1D/Tensor1D.lean
+++ b/SSA/Projects/Tensor1D/Tensor1D.lean
@@ -12,8 +12,6 @@ simple examples of 1D tensors, as per MLIR.
 -/
 abbrev Index := ℕ
 
-
-namespace Val
 -- pure simply typed lambda calculus
 structure Tensor1d (α : Type) [Inhabited α] where
   size : Index
@@ -302,8 +300,6 @@ theorem Tensor1d.tile [Inhabited α] (t : Tensor1d α) (SIZE : 4 ∣ t.size) (f 
     sorry
 }
 
-namespace ArithScfLinalg
-
 /--
 We make the following simplifying assumptions in the IR:
 - Currently, there is no way to *build* a tensor, we only have operations on them.
@@ -413,5 +409,4 @@ theorem extract_map (r0 : TSSA Op Context.empty _) :
     simp[Tensor1d.extract_map]
   }
 -/
-end ArithScfLinalg
 end Tensor1D

--- a/SSA/Projects/Tensor1D/Tensor1D.lean
+++ b/SSA/Projects/Tensor1D/Tensor1D.lean
@@ -310,7 +310,7 @@ We make the following simplifying assumptions in the IR:
 This matches the MLIR model, which has a separate `index` type for indexing
 and `iXX/f32/f64` types for values held in tensors.
 -/
-inductive ExOp
+inductive Op
 | /-- add two integers -/ add_int
 | /-- create a constant index -/ const_ix (v: Index)
 | /-- subtract two integers -/ sub_int
@@ -318,26 +318,26 @@ inductive ExOp
 | /-- extract a value at an index of a tensor -/ extract1d
 deriving DecidableEq
 
-inductive ExTy
-| /-- values held in tensors -/ int : ExTy 
-| /-- shapes and indexes of tensors -/ ix : ExTy
-| /-- tensor type -/ tensor1d  : ExTy
+inductive Ty
+| /-- values held in tensors -/ int : Ty 
+| /-- shapes and indexes of tensors -/ ix : Ty
+| /-- tensor type -/ tensor1d  : Ty
 deriving DecidableEq, Inhabited
 
-instance : Goedel ExTy where
+instance : Goedel Ty where
   toType
   | .int => Int
   | .ix => Index
   | .tensor1d => Tensor1d Int
 
-instance : OpSignature ExOp ExTy where
-  outTy : ExOp → ExTy
+instance : OpSignature Op Ty where
+  outTy : Op → Ty
   | .add_int => .int
   | .sub_int => .int
   | .const_ix _ => .ix
   | .map1d =>  .tensor1d
   | .extract1d =>  .tensor1d
-  sig  : ExOp → List ExTy
+  sig  : Op → List Ty
   | .add_int => [.int, .int]
   | .sub_int => [.int, .int]
   | .map1d => [.tensor1d]
@@ -351,7 +351,7 @@ instance : OpSignature ExOp ExTy where
 /-
 -- Error: unknown free variable: _kernel_fresh.459
 @[reducible]
-instance : OpDenote ExOp ExTy where
+instance : OpDenote Op Ty where
   denote
   | .const_ix v, _, _ => v
   | .add_int, (.cons x (.cons y nil)), _ =>

--- a/SSA/Projects/Tensor2D/Tensor2D.lean
+++ b/SSA/Projects/Tensor2D/Tensor2D.lean
@@ -175,7 +175,7 @@ theorem map_fill_2d
            (op:constIx(ix₀) (), op:constIx(ix₁) ())),
            op:constTensor(t) ()))
   ] =
-  TSSA.eval (e := e) (Op := Op) (β := ) [dsl_bb2|
+  TSSA.eval (e := e) (Op := Op) [dsl_bb2|
     return op:extract2d 
       (((op:constIx(sz₀) (), op:constIx(sz₁) ()),
         (op:constIx(ix₀) (), op:constIx(ix₁) ())),

--- a/SSA/Projects/Tensor2D/Tensor2D.lean
+++ b/SSA/Projects/Tensor2D/Tensor2D.lean
@@ -1,5 +1,4 @@
-import SSA.Core.WellTypedFramework
-import SSA.Core.EDSLNested
+import SSA.Core.Framework
 import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Nat.Basic
 import SSA.Core.Util
@@ -81,7 +80,7 @@ theorem Tensor2d'.fill_extract (δ₀ δ₁ sz₀ sz₁ : ℕ) (t : Tensor2d' α
 }
 
 
-inductive Op
+inductive ExOp
 | add
 -- TODO: generalize 'const'
 | constIx (v: Nat) | constTensor (t : Tensor2d' Int) | constInt (v : Int)
@@ -90,106 +89,70 @@ inductive Op
 | fill2d
 | extract2d 
 
-inductive BaseType
-| int : BaseType
-| ix : BaseType
-| tensor2d : BaseType
+inductive ExTy
+| int : ExTy
+| ix : ExTy
+| tensor2d : ExTy
 deriving DecidableEq, Inhabited
 
-def BaseType.toType : BaseType → Type
+def ExTy.toType : ExTy → Type
 | .int => Int
 | .ix => Index
 | .tensor2d => Tensor2d' Int -- TODO: eventually generalize to arbitrary type.
 
-instance : Goedel BaseType where toType := BaseType.toType
+instance : Goedel ExTy where toType := ExTy.toType
 
-abbrev UserType := SSA.UserType BaseType
+@[reducible]
+instance : OpSignature ExOp ExTy where
+  outTy : ExOp → ExTy
+  | .add => .int
+  | .sub => .int
+  | .constIx _ => .ix 
+  | .constTensor _ => .tensor2d
+  | .constInt _ => .int
+  | .map2d | .fill2d => .tensor2d
+  | .extract2d => .tensor2d
 
--- Can we get rid of the code repetition here? (not that copilot has any trouble completing this)
-@[simp]
-def argUserType : Op → UserType
-| Op.add => ↑(BaseType.int, BaseType.int)
-| Op.sub => ↑(BaseType.int, BaseType.int)
-| Op.constIx _  => ()
-| Op.constTensor _  => ()
-| Op.constInt _  => ()
-| Op.map2d => BaseType.tensor2d
-| Op.fill2d => (BaseType.int, BaseType.tensor2d)
-| Op.extract2d => (((BaseType.ix, BaseType.ix), (BaseType.ix, BaseType.ix)), BaseType.tensor2d)
+  sig  : ExOp → List ExTy
+  | .add => [.int, .int]
+  | .sub => [.int, .int]
+  | .constIx _  => []
+  | .constTensor _  => []
+  | .constInt _  => []
+  | .map2d => [.tensor2d]
+  | .fill2d => [.int, .tensor2d]
+  | .extract2d => [.ix, .ix, .ix, .ix, .tensor2d]
+  
+  regSig
+  | .map2d => [([.int], .int)]
+  | _ => []
 
-@[simp]
-def outUserType : Op → UserType
-| Op.add => BaseType.int
-| Op.sub => BaseType.int
-| Op.constIx _ => BaseType.ix 
-| Op.constTensor _ => BaseType.tensor2d
-| Op.constInt _ => BaseType.int
-| Op.map2d | Op.fill2d => BaseType.tensor2d
-| Op.extract2d => BaseType.tensor2d
-
-@[simp]
-def rgnDom : Op → UserType
-| Op.add | Op.sub | Op.fill2d | Op.extract2d  => .unit
-| Op.constIx _ | Op.constTensor _ | Op.constInt _ => .unit
-| Op.map2d => BaseType.int
-
-@[simp]
-def rgnCod : Op → UserType
-| Op.add | Op.sub | Op.fill2d  | Op.extract2d => .unit
-| Op.constIx _ | Op.constTensor _ | Op.constInt _ => .unit
-| Op.map2d => BaseType.int
-
-def eval (o : Op)
-  (arg: Goedel.toType (argUserType o))
-  (_rgn : (Goedel.toType (rgnDom o) → (Goedel.toType (rgnCod o)))) :
-  (Goedel.toType (outUserType o)) :=
-  match o with
-  | .constIx v => v
-  | .constTensor v => v
-  | .constInt v => v
-  | .add => 
-    let (x, y) := arg;
+/-
+-- error: unknown free variable: _kernel_fresh.97
+@[reducible]
+instance : OpDenote ExOp ExTy where
+  denote
+  | .constIx v, _, _ => v
+  | .constTensor v, _, _ => v
+  | .constInt v, _, _ => v
+  | .add, (.cons x (.cons y nil)), _ => 
     let x : Int := x;
     let y : Int := y;
     x + y
-  | .sub =>
-    let (x, y) := arg;
+  | .sub, (.cons x (.cons y nil)), _ =>
     let x : Int := x;
     let y : Int := y;
-    x - y
-  | .map2d => 
-    let t : Tensor2d' Int := arg
-    let f : Int → Int := _rgn
+    let out : Int := x - y
+    out
+  | .map2d, (.cons t .nil), (.cons r .nil) => 
+    let t : Tensor2d' Int := t
+    -- Is there a cleaner way to build the data below?
+    let f : Int → Int := fun v =>  r (Ctxt.Valuation.ofList <| (.cons v .nil))
     t.map f
-  | .fill2d => 
-    let (v, t) : Int × Tensor2d' Int  := arg
+  | .fill2d, (.cons v (.cons t nil)), _ => 
     t.fill v
-  | .extract2d => 
-    let ((δ, sz), t) := arg
-    t.extract δ.fst δ.snd sz.fst sz.snd
-    
-instance TUS : SSA.TypedUserSemantics Op BaseType where
-  argUserType := argUserType
-  rgnDom := rgnDom
-  rgnCod := rgnCod
-  outUserType := outUserType
-  eval := eval
-
-syntax "map2d" : dsl_op2
-syntax "fill2d" : dsl_op2
-syntax "extract2d" : dsl_op2
-syntax "constIx" "(" term ")" : dsl_op2
-syntax "constTensor" "(" term ")" : dsl_op2
-syntax "constInt" "(" term ")" : dsl_op2
-
-open EDSL2 in
-macro_rules
-| `([dsl_op2| map2d]) => `(Op.map2d)
-| `([dsl_op2| fill2d]) => `(Op.fill2d)
-| `([dsl_op2| extract2d]) => `(Op.extract2d)
-| `([dsl_op2| constIx($t)]) => `(Op.constIx $t)
-| `([dsl_op2| constTensor($t)]) => `(Op.constTensor $t)
-| `([dsl_op2| constInt($t)]) => `(Op.constInt $t)
+  | .extract2d, (.cons δ₁ (.cons δ₂ (.cons sz₁ (.cons sz₂ (.cons t .nil))))), _ => 
+    t.extract δ₁ δ₂ sz₁ sz₂
 
 -- NOTE: there is no way in MLIR to talk about composition of functions, so `map . map` is out
 --       as a peephole rewrite
@@ -205,14 +168,14 @@ theorem map_fill_2d
     (sz₀ sz₁ ix₀ ix₁: Index) 
     (i : Int):
   TSSA.eval
-  (e := e) (Op := Op) (β := BaseType) [dsl_bb2|
+  (e := e) (Op := Op) (β := ) [dsl_bb2|
     return op:fill2d (op:constInt(i) (), 
       op:extract2d (
           ((op:constIx(sz₀) () , op:constIx(sz₁) ()),
            (op:constIx(ix₀) (), op:constIx(ix₁) ())),
            op:constTensor(t) ()))
   ] =
-  TSSA.eval (e := e) (Op := Op) (β := BaseType) [dsl_bb2|
+  TSSA.eval (e := e) (Op := Op) (β := ) [dsl_bb2|
     return op:extract2d 
       (((op:constIx(sz₀) (), op:constIx(sz₁) ()),
         (op:constIx(ix₀) (), op:constIx(ix₁) ())),
@@ -222,3 +185,4 @@ theorem map_fill_2d
     simp[UserType.mkPair, TypedUserSemantics.eval, eval]
     simp[Tensor2d'.fill_extract]
   }
+-/

--- a/SSA/Projects/Tensor2D/Tensor2D.lean
+++ b/SSA/Projects/Tensor2D/Tensor2D.lean
@@ -80,7 +80,7 @@ theorem Tensor2d'.fill_extract (δ₀ δ₁ sz₀ sz₁ : ℕ) (t : Tensor2d' α
 }
 
 
-inductive ExOp
+inductive Op
 | add
 -- TODO: generalize 'const'
 | constIx (v: Nat) | constTensor (t : Tensor2d' Int) | constInt (v : Int)
@@ -89,22 +89,22 @@ inductive ExOp
 | fill2d
 | extract2d 
 
-inductive ExTy
-| int : ExTy
-| ix : ExTy
-| tensor2d : ExTy
+inductive Ty
+| int : Ty
+| ix : Ty
+| tensor2d : Ty
 deriving DecidableEq, Inhabited
 
-def ExTy.toType : ExTy → Type
+def Ty.toType : Ty → Type
 | .int => Int
 | .ix => Index
 | .tensor2d => Tensor2d' Int -- TODO: eventually generalize to arbitrary type.
 
-instance : Goedel ExTy where toType := ExTy.toType
+instance : Goedel Ty where toType := Ty.toType
 
 @[reducible]
-instance : OpSignature ExOp ExTy where
-  outTy : ExOp → ExTy
+instance : OpSignature Op Ty where
+  outTy : Op → Ty
   | .add => .int
   | .sub => .int
   | .constIx _ => .ix 
@@ -113,7 +113,7 @@ instance : OpSignature ExOp ExTy where
   | .map2d | .fill2d => .tensor2d
   | .extract2d => .tensor2d
 
-  sig  : ExOp → List ExTy
+  sig  : Op → List Ty
   | .add => [.int, .int]
   | .sub => [.int, .int]
   | .constIx _  => []
@@ -130,7 +130,7 @@ instance : OpSignature ExOp ExTy where
 /-
 -- error: unknown free variable: _kernel_fresh.97
 @[reducible]
-instance : OpDenote ExOp ExTy where
+instance : OpDenote Op Ty where
   denote
   | .constIx v, _, _ => v
   | .constTensor v, _, _ => v

--- a/SSA/Projects/Tensor2D/Tensor2D.lean
+++ b/SSA/Projects/Tensor2D/Tensor2D.lean
@@ -168,7 +168,7 @@ theorem map_fill_2d
     (sz₀ sz₁ ix₀ ix₁: Index) 
     (i : Int):
   TSSA.eval
-  (e := e) (Op := Op) (β := ) [dsl_bb2|
+  (e := e) (Op := Op) [dsl_bb2|
     return op:fill2d (op:constInt(i) (), 
       op:extract2d (
           ((op:constIx(sz₀) () , op:constIx(sz₁) ()),

--- a/SSA/Projects/Tensor2D/Tensor2D.lean
+++ b/SSA/Projects/Tensor2D/Tensor2D.lean
@@ -147,7 +147,7 @@ instance : OpDenote Op Ty where
   | .map2d, (.cons t .nil), (.cons r .nil) => 
     let t : Tensor2d' Int := t
     -- Is there a cleaner way to build the data below?
-    let f : Int → Int := fun v =>  r (Ctxt.Valuation.ofList <| (.cons v .nil))
+    let f : Int → Int := fun v =>  r (Ctxt.Valuation.ofHVector <| (.cons v .nil))
     t.map f
   | .fill2d, (.cons v (.cons t nil)), _ => 
     t.fill v

--- a/SSA/Projects/Tensor2D/Tensor2D.lean
+++ b/SSA/Projects/Tensor2D/Tensor2D.lean
@@ -4,10 +4,10 @@ import Mathlib.Data.Nat.Basic
 import SSA.Core.Util
 import SSA.Core.Util
 
-
+namespace Tensor2D
 /-- Type of tensor dimensions and indexes into tensor dimensions.
   NOTE: see interaction with `linarith` where we need to unfold `Index` into `ℕ`
-    https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Ergonomics.3A.20linarith.20does.20not.20work.20on.20Nat.20alias/near/365631549
+  https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Ergonomics.3A.20linarith.20does.20not.20work.20on.20Nat.20alias/near/365631549
 -/
 abbrev Index := ℕ
 
@@ -186,3 +186,4 @@ theorem map_fill_2d
     simp[Tensor2d'.fill_extract]
   }
 -/
+end Tensor2D


### PR DESCRIPTION
We see the dreaded error

> -- Error: unknown free variable: _kernel_fresh.459

in our instance definition

```lean
instance : OpDenote ExOp ExTy where
...
```

This suggests that we should spend the time working around
or fixing this kernel bug.
