### PR TITLE
alive - fix broken >= notation

### DIFF
--- a/SSA/Projects/InstCombine/ForStd.lean
+++ b/SSA/Projects/InstCombine/ForStd.lean
@@ -7,13 +7,13 @@ def ofBool : (Bool) -> Std.BitVec 1
 
 notation:50 x " ≤ᵤ " y => BitVec.ule x y
 notation:50 x " <ᵤ " y => BitVec.ult x y
-notation:50 x " ≥ᵤ " y => BitVec.ult y x
-notation:50 x " >ᵤ " y => BitVec.ule y x
+notation:50 x " ≥ᵤ " y => BitVec.ule y x
+notation:50 x " >ᵤ " y => BitVec.ult y x
 
 notation:50 x " ≤ₛ " y => BitVec.sle x y
 notation:50 x " <ₛ " y => BitVec.slt x y
-notation:50 x " ≥ₛ " y => BitVec.slt y x
-notation:50 x " >ₛ " y => BitVec.sle y x
+notation:50 x " ≥ₛ " y => BitVec.sle y x
+notation:50 x " >ₛ " y => BitVec.slt y x
 
 instance {n} : ShiftLeft (BitVec n) := ⟨fun x y => x <<< y.toNat⟩
 


### PR DESCRIPTION
The operations sle and slt where switched.