### PR TITLE
Remove `snoc'`

### DIFF
--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -220,11 +220,11 @@ def Valuation.snoc {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType t) :
   . intro _ _ _ v s _; exact s v
   . intro _ _ _ x; exact x
 
-def Valuation.snoc' {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType t) : 
-    (Γ.snoc t).Valuation := 
+def Valuation.snoc' {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType t) :
+    (Γ.snoc t).Valuation :=
   fun t' var =>
     match var with
-    | ⟨i, hvar⟩ =>  
+    | ⟨i, hvar⟩ =>
       match i with
       | 0 => by
         simp[Ctxt.snoc] at hvar
@@ -232,22 +232,18 @@ def Valuation.snoc' {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType t) :
       | .succ i' => s ⟨i', hvar⟩
 
 /-- Show the equivalence between the definition in terms of `snoc` and `snoc'`. -/
-theorem Valuation.snoc_eq_snoc' {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType t) 
-    : (s.snoc x) = (s.snoc' x) := by
-  simp[snoc, snoc']
+theorem Valuation.snoc_eq_snoc' {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType t) :
+    (s.snoc x) = fun t var => match var with
+      | ⟨0, hvar⟩ => by
+          simp[Ctxt.snoc] at hvar
+          exact (hvar ▸ x)
+      | ⟨.succ i, hvar⟩ => s ⟨i, hvar⟩ := by
   funext t' v
-  cases V:v
-  case mk i hi => 
-    simp
-    simp[Var.casesOn]
-    cases i
-    case zero => 
-      simp
-      simp[Ctxt.snoc] at hi
-      subst hi
-      simp
-    case succ i' => 
-      simp
+  rcases v with ⟨⟨⟩|i, hi⟩
+  · injection hi with hi
+    subst hi
+    rfl
+  · rfl
 
 @[simp]
 theorem Valuation.snoc_last {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType t) :

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1162,9 +1162,12 @@ leaving behind a bare Lean level proposition to be proven.
 macro "simp_peephole" "[" ts: Lean.Parser.Tactic.simpLemma,* "]" "at" ll:ident : tactic =>
   `(tactic|
       (
-      try simp (config := {decide := false}) only [Com.denote, Expr.denote, HVector.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
-        Ctxt.empty, Ctxt.snoc, Ctxt.Valuation.nil, Ctxt.Valuation.snoc', Ctxt.Valuation.snoc_last, Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
-        HVector.map, HVector.toPair, HVector.toTuple, OpDenote.denote, Expr.op_mk, Expr.args_mk, $ts,*]
+      try simp (config := {decide := false}) only [
+        Com.denote, Expr.denote, HVector.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
+        Ctxt.empty, Ctxt.empty_eq, Ctxt.snoc, Ctxt.Valuation.nil, Ctxt.Valuation.snoc_last,
+        Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
+        HVector.map, HVector.toPair, HVector.toTuple, OpDenote.denote, Expr.op_mk, Expr.args_mk,
+        $ts,*]
       generalize $ll { val := 0, property := _ } = a;
       generalize $ll { val := 1, property := _ } = b;
       generalize $ll { val := 2, property := _ } = c;

--- a/SSA/Projects/DCE/DCE.lean
+++ b/SSA/Projects/DCE/DCE.lean
@@ -264,47 +264,23 @@ theorem Deleted.pushforward_Valuation_snoc {Γ Γ' : Ctxt Ty} {ω : Ty} {delv : 
   (V : Γ.Valuation) {newv : Goedel.toType ω} :
   DELω.pushforward_Valuation (V.snoc newv) =
   (DEL.pushforward_Valuation V).snoc newv := by
-    simp[Deleted.pushforward_Valuation]
-    repeat rw[Ctxt.Valuation.snoc_eq_snoc']
-    simp[Ctxt.Valuation.snoc']
-    simp[Deleted.pullback_var]
+    simp only [Deleted.pushforward_Valuation, Deleted.pullback_var, Ctxt.get?, Ctxt.Var.val_toSnoc,
+      Ctxt.Var.succ_eq_toSnoc, Ctxt.Valuation.snoc_eq]
     funext t var
-    split_ifs
-    case pos =>
-      simp[Ctxt.Var.casesOn]
-      cases var
-      case mk i hvar EQN =>
-        simp
-        simp at EQN
-        cases i
-        case zero =>
-          simp
-        case succ i' =>
-          simp
-          split_ifs
-          case pos =>
-            rfl
-          case neg =>
-            exfalso
-            linarith
-    case neg =>
-      cases var
-      case mk i hvar EQN =>
-        simp at EQN ⊢
-        simp only[Ctxt.Var.toSnoc]
-        cases i
-        case zero =>
-          simp
-          exfalso
-          linarith
-        case succ i' =>
-          simp at i' ⊢
-          split_ifs
-          case pos =>
-            exfalso
-            linarith
-          case neg =>
-            rfl
+    rcases var with ⟨i, hvar⟩
+    split_ifs with EQN <;> (
+      simp only [Ctxt.get?, Ctxt.Var.toSnoc]
+      simp at EQN
+      cases i <;> simp only
+    )
+    case neg.zero =>
+      exfalso
+      linarith
+    all_goals
+      split_ifs <;>
+        solve
+        | rfl
+        | exfalso; linarith
 
 /-- Delete a variable from an Com. -/
 def Com.deleteVar? (DEL : Deleted Γ delv Γ') (com : Com Op Γ t) :
@@ -346,7 +322,7 @@ instance [SIG : OpSignature Op Ty] [DENOTE : OpDenote Op Ty] {Γ : Ctxt Ty} {t :
 
 /-- walk the list of bindings, and for each `let`, try to delete the variable defined by the `let` in the body/
 Note that this is `O(n^2)`, for an easy proofs, as it is written as a forward pass.
-The fast `O(n)` version is a backward pass. 
+The fast `O(n)` version is a backward pass.
 -/
 partial def dce_ [OpSignature Op Ty] [OpDenote Op Ty]  {Γ : Ctxt Ty} {t : Ty} (com : Com Op Γ t) : DCEType com :=
     match HCOM: com with

--- a/SSA/Projects/PaperExamples/PaperExamples.lean
+++ b/SSA/Projects/PaperExamples/PaperExamples.lean
@@ -127,7 +127,7 @@ instance : OpDenote Op Ty where
     | .const n, _, _ => BitVec.ofInt 32 n
     | .add, .cons (a : BitVec 32) (.cons (b : BitVec 32) .nil), _ => a + b
     | .iterate k, (.cons (x : BitVec 32) .nil), (.cons (f : _ → BitVec 32) .nil) =>
-      let f' (v :  BitVec 32) : BitVec 32 := f  (Ctxt.Valuation.nil.snoc' v)
+      let f' (v :  BitVec 32) : BitVec 32 := f  (Ctxt.Valuation.nil.snoc v)
       k.iterate f' x
       -- let f_k := Nat.iterate f' k
       -- f_k x
@@ -168,9 +168,6 @@ def rhs : Com Op [.int] .int :=
 
 attribute [local simp] Ctxt.snoc
 
-@[simp]
-theorem Ctxt.Valuation.snoc_last [Goedel Ty] {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : Goedel.toType ty):
-  (Ctxt.Valuation.snoc V v) (Ctxt.Var.last _ _) = v := rfl
 set_option pp.proofs false in
 set_option pp.proofs.withType false in
 def p1 : PeepholeRewrite Op [.int] .int:=


### PR DESCRIPTION
The core issue was `Valuation.snoc_last` not applying
because one context was spelled \emptyset, while the other was spelled `[]`
By being more consistent, and introducing a simp-lemma that rewrites the former to the latter
we remove the need for `snoc'`.