### PR TITLE
fromTensor: full proof works, two believed sorrys are to be filled in

### DIFF
--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -387,7 +387,7 @@ noncomputable def R.repLength {q n} (a : R q n) : Nat := match
 /- the repLength of any value is ≤ 1 + its natDegree. -/
 theorem R.repLength_leq_representative_degree_plus_1 (a : R q n) :
   a.repLength ≤ (R.representative q n a).natDegree + 1 := by
-  simp[repLength]
+  simp [repLength]
   generalize hdegree : degree (representative q n a) = d
   cases' d with d <;> simp[natDegree, hdegree, WithBot.unbot', WithBot.recBotCoe]
 
@@ -505,12 +505,11 @@ theorem Polynomial.degree_toFinsupp [Semiring M] [DecidableEq M]
   (xs : List M) :
   degree { toFinsupp := List.toFinsupp (l := xs) } ≤ List.length xs := by
     cases xs
-    case nil =>
-      simp[degree]
+    case nil => simp [degree]
     case cons x xs =>
-      simp[degree]
-      simp[List.toFinsupp]
-      simp[Finset.range_succ]
+      simp [degree]
+      simp [List.toFinsupp]
+      simp [Finset.range_succ]
       apply Finset.max_le
       intros a ha
       obtain ⟨ha₁, ha₂⟩ := Finset.mem_filter.mp ha
@@ -519,13 +518,13 @@ theorem Polynomial.degree_toFinsupp [Semiring M] [DecidableEq M]
       . subst ha₄
         norm_cast
         apply WithBot.coe_le_coe.mpr
-        simp[Nat.cast]
+        simp [Nat.cast]
       . have ha₆ := Finset.mem_range.mp ha₅
         norm_cast
         apply WithBot.coe_le_coe.mpr
         norm_cast
         simp at ha₆ ⊢
-        simp[Nat.le_add_one_iff, ha₆]
+        simp [Nat.le_add_one_iff, ha₆]
         left
         apply Nat.le_of_lt ha₆
 
@@ -597,17 +596,16 @@ theorem R.coeff_fromPoly {q n : ℕ} [Fact (q > 1)] (p : (ZMod q)[X]) : R.coeff 
   3.
 -/
 /-- The coefficient of `fromTensor` is the same as the values available in the tensor input. -/
-theorem R.coeff_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int)
-(htensorlen : tensor.length < 2^n)
+theorem R.coeff_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int) (htensorlen : tensor.length < 2^n)
 : (R.fromTensor (q := q) (n := n) tensor).coeff i = (tensor.getD i 0) := by
   rw[fromTensor_eq_fromTensorFinsupp_fromPoly]
   have hfromTensorFinsuppDegree := fromTensorFinsupp_degree q tensor
-  rw[coeff]
-  rw[representative_fromPoly_eq]
+  rw [coeff]
+  rw [representative_fromPoly_eq]
   apply fromTensorFinsupp_coeffs
   case DEGREE =>
     generalize htensor_degree : degree (fromTensorFinsupp q tensor) = tensor_degree
-    rw[f_deg_eq]
+    rw [f_deg_eq]
     cases tensor_degree
     case none => norm_cast; apply WithBot.none_lt_some
     case some tensor_degree =>
@@ -616,9 +614,9 @@ theorem R.coeff_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int)
       apply WithBot.coe_strictMono
       norm_cast
       have htrans : tensor_degree  ≤ List.length tensor := by
-        rw[htensor_degree] at hfromTensorFinsuppDegree
-        rw[WithBot.some_eq_coe] at hfromTensorFinsuppDegree
-        rw[← WithBot.coe_le_coe]
+        rw [htensor_degree] at hfromTensorFinsuppDegree
+        rw [WithBot.some_eq_coe] at hfromTensorFinsuppDegree
+        rw [← WithBot.coe_le_coe]
         assumption
       apply Nat.lt_of_le_of_lt htrans htensorlen
 
@@ -637,7 +635,7 @@ noncomputable def R.toTensor {q n} [Fact (q > 1)] (a : R q n) : List Int :=
 
 /-- The length of the tensor `R.toTensor a` equals `a.repLength` -/
 theorem R.toTensor_length {q n} [Fact (q > 1)] (a : R q n) : (R.toTensor a).length = a.repLength := by
-  simp[R.toTensor, List.length_range]
+  simp [R.toTensor, List.length_range]
 
 /--
 Converts an element of `R` into a tensor (modeled as a `List Int`)

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -18,6 +18,7 @@ import Mathlib.Data.ZMod.Basic
 import Mathlib.Algebra.MonoidAlgebra.Basic
 import Mathlib.Data.Finset.Sort
 import Mathlib.Data.List.ToFinsupp
+import Mathlib.Data.List.Basic
 import Mathlib.Data.Polynomial.RingDivision
 import SSA.Core.Framework
 
@@ -491,17 +492,41 @@ theorem R.fromTensor_eq_fromTensor'_fromPoly {q n} : R.fromTensor (q := q) (n :=
 noncomputable def R.fromTensorFinsupp (coeffs : List ℤ) : (ZMod q)[X] :=
   Polynomial.ofFinsupp (List.toFinsupp (coeffs.map Int.cast))
 
+theorem Polynomial.degree_toFinsupp [Semiring M] [DecidableEq M]
+  (xs : List M) :
+  degree { toFinsupp := List.toFinsupp (l := xs) } ≤ List.length xs := by
+    cases xs
+    case nil =>
+      simp[degree]
+    case cons x xs =>
+      simp[degree]
+      simp[List.toFinsupp]
+      simp[Finset.range_succ]
+      apply Finset.max_le
+      intros a ha
+      obtain ⟨ha₁, ha₂⟩ := Finset.mem_filter.mp ha
+      have ha₃ := Finset.mem_insert.mp ha₁
+      cases' ha₃ with ha₄ ha₅
+      . subst ha₄
+        norm_cast
+        apply WithBot.coe_le_coe.mpr
+        simp[Nat.cast]
+      . have ha₆ := Finset.mem_range.mp ha₅
+        norm_cast
+        apply WithBot.coe_le_coe.mpr
+        norm_cast
+        simp at ha₆ ⊢
+        simp[Nat.le_add_one_iff, ha₆]
+        left
+        apply Nat.le_of_lt ha₆
+
 /-- degree of fromTensorFinsupp is at most the length of the coefficient list. -/
 theorem R.fromTensorFinsupp_degree (coeffs : List ℤ) :
   (R.fromTensorFinsupp q coeffs).degree ≤ coeffs.length := by
   rw [fromTensorFinsupp]
-  rw [degree]
-  simp [Polynomial.eta]
-  rw [List.toFinsupp_support]
-  rw [Finset.max]
-  sorry
-
-
+  have hdeg := Polynomial.degree_toFinsupp (List.map (Int.cast (R := ZMod q)) coeffs)
+  simp[List.length_map] at hdeg
+  assumption
 
 /-- the ith coefficient of fromTensorFinsupp is a coercion of the 'coeffs' into the right list. -/
 theorem R.fromTensorFinsupp_coeffs (coeffs : List ℤ) :

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -499,6 +499,7 @@ theorem R.fromTensorFinsupp_degree (coeffs : List ℤ) :
   simp [Polynomial.eta]
   rw [List.toFinsupp_support]
   rw [Finset.max]
+  sorry
 
 
 
@@ -555,12 +556,6 @@ theorem R.coeff_fromPoly {q n : ℕ} [Fact (q > 1)] (p : (ZMod q)[X]) : R.coeff 
   have H := R.representative_fromPoly_toFun (a := p) (n := n)
   norm_cast at H ⊢
 
-
-/-- since `0` is the additive identity, getting from `(x :: xs)` at index `i` with -/
-theorem List.getD_snoc_zero (x : ℤ) (xs : List ℤ) :
-  (xs ++ [x]).getD i 0 = (xs.getD i 0) + (if i == xs.length then x else 0) := by sorry
-
-
 /- 1. given a list of coefficients, building the ring element and then picking the repr from
    the equiv class, is the same as taking modulo (`representative_fromPoly_toFun`)
    2. if the length is less than 2^n, then the modulo by`f` equals the element itself
@@ -577,15 +572,21 @@ theorem R.coeff_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int)
   rw[representative_fromPoly_eq]
   apply fromTensorFinsupp_coeffs
   case DEGREE =>
-    /- chain
-        htensorlen: List.length tensor < 2 ^ n
-      with
-       hfromTensorFinsuppDegree: degree (fromTensorFinsupp q tensor) ≤ ↑(List.length tensor)
-      to show
-        degree (fromTensorFinsupp q tensor) < degree (f q n)
-    -/
-    sorry
-
+    generalize htensor_degree : degree (fromTensorFinsupp q tensor) = tensor_degree
+    rw[f_deg_eq]
+    cases tensor_degree
+    case none => norm_cast; apply WithBot.none_lt_some
+    case some tensor_degree =>
+      /- I hate this coercion stuff -/
+      norm_cast
+      apply WithBot.coe_strictMono
+      norm_cast
+      have htrans : tensor_degree  ≤ List.length tensor := by
+        rw[htensor_degree] at hfromTensorFinsuppDegree
+        rw[WithBot.some_eq_coe] at hfromTensorFinsuppDegree
+        rw[← WithBot.coe_le_coe]
+        assumption
+      apply Nat.lt_of_le_of_lt htrans htensorlen
 
 theorem R.representative_fromTensor_eq_fromTensor' (tensor : List ℤ) : R.representative q n (R.fromTensor tensor) = R.representative' q n (R.fromTensor' q tensor)  %ₘ (f q n) := by
   simp [R.representative]

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -384,6 +384,15 @@ noncomputable def R.repLength {q n} (a : R q n) : Nat := match
     | none => 0
     | some d => d + 1
 
+/- the repLength of any value is ≤ 1 + its natDegree. -/
+theorem R.repLength_leq_representative_degree_plus_1 (a : R q n) :
+  a.repLength ≤ (R.representative q n a).natDegree + 1 := by
+  simp[repLength]
+  generalize hdegree : degree (representative q n a) = d
+  cases' d with d <;> simp[natDegree, hdegree, WithBot.unbot', WithBot.recBotCoe]
+
+
+
 theorem R.repLength_lt_n_plus_1 : forall a : R q n, a.repLength < 2^n + 1 := by
   intro a
   simp [R.repLength, representative]
@@ -625,6 +634,10 @@ The length of the list is the degree of the representative + 1.
 noncomputable def R.toTensor {q n} [Fact (q > 1)] (a : R q n) : List Int :=
   List.range a.repLength |>.map fun i =>
         a.coeff i |>.toInt
+
+/-- The length of the tensor `R.toTensor a` equals `a.repLength` -/
+theorem R.toTensor_length {q n} [Fact (q > 1)] (a : R q n) : (R.toTensor a).length = a.repLength := by
+  simp[R.toTensor, List.length_range]
 
 /--
 Converts an element of `R` into a tensor (modeled as a `List Int`)

--- a/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
@@ -223,42 +223,25 @@ theorem R.trim_toTensor'_eq_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) :
 
 theorem toTensor_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int) (i : Nat) (htensorlen : List.length tensor < 2 ^ n):
   (R.fromTensor tensor (q:=q) (n :=n)).toTensor.getD i 0 = (tensor.getD i 0) % q := by
-  simp[R.toTensor_getD]
-  simp[ZMod.toInt];
-  rw[R.coeff_fromTensor (hqgt1 := hqgt1) (htensorlen := htensorlen)]
+  simp [R.toTensor_getD]
+  simp [ZMod.toInt]
+  rw [R.coeff_fromTensor (hqgt1 := hqgt1) (htensorlen := htensorlen)]
   norm_cast
-  simp[Int.cast, ZMod.cast]
+  simp [Int.cast, ZMod.cast]
   cases q;
   case zero =>
     exfalso
     simp at hqgt1
     exact (Fact.elim hqgt1)
   case succ q' =>
-    simp
-    simp[ZMod.cast]
+    simp [ZMod.cast]
     norm_cast
-    simp[IntCast.intCast]
+    simp [IntCast.intCast]
     norm_cast
     ring_nf
-    rw[ZMod.cast_eq_val]
-    rw[ZMod.val_int_cast]
+    rw [ZMod.cast_eq_val]
+    rw [ZMod.val_int_cast]
     ring_nf
-
-theorem toTensor_fromTensor_trimTensor_eq_trimTensor [hqgt1 : Fact (q > 1)] (a : R q n) (tensor : List Int) {l : Nat}:
-  Polynomial.degree a.representative = .some l → tensor.length < l →
-  (R.fromTensor (trimTensor tensor) (q:=q) (n :=n)).toTensor = trimTensor tensor := by
-  intros hDeg hLen
-  simp [R.fromTensor, R.toTensor]
-  sorry
-
-theorem toTensor_fromTensor_eq_trimTensor [hqgt1 : Fact (q > 1)] (a : R q n) (tensor : List Int) {l : Nat}:
-  Polynomial.degree a.representative = .some l → tensor.length < l →
-  (R.fromTensor tensor (q:=q) (n :=n)).toTensor = trimTensor tensor := by
-  intros hDeg hLen
-  --simp [R.fromTensor, R.toTensor]
-  have ⟨n,hTrim⟩ := R.trimTensor_eq_append_zeros tensor
-  rw [hTrim,R.trimTensor_append_zeroes_eq, R.fromTensor_eq_concat_zeroes, R.trimTensor_trimTensor]
-  apply toTensor_fromTensor_trimTensor_eq_trimTensor _ _ hDeg hLen
 
 /- TODO: this should be a theorem that we prove, that the length of anything that comes from `R.toTensor` will be < 2^n -/
 theorem fromTensor_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) (adeg : (R.representative q n a).natDegree + 1 < 2^n) : R.fromTensor a.toTensor = a := by
@@ -266,7 +249,7 @@ theorem fromTensor_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) (adeg : (R.repres
     | none =>
         have h' :=  Polynomial.degree_eq_bot.1 h
         rw [← rep_zero] at h'
-        have h'':= (eq_iff_rep_eq _ _).1 h'
+        have h'' := (eq_iff_rep_eq _ _).1 h'
         simp [R.fromTensor, R.toTensor, R.repLength]; rw [h, h'']
         simp
     | some deg =>
@@ -277,7 +260,7 @@ theorem fromTensor_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) (adeg : (R.repres
         intro i
         rw [← hCoeff, ← hCoeff]
         rw [toTensor_fromTensor]
-        rw[← ZMod.coe_int_cast]
+        rw [← ZMod.coe_int_cast]
         norm_cast
         . simp [R.toTensor_length]
           have hdeg := R.repLength_leq_representative_degree_plus_1 q n a

--- a/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
@@ -58,12 +58,6 @@ theorem monomial_mul_mul (x y : Nat) : (R.monomial 1 y) * (R.monomial 1 x) = R.m
 
 end Poly
 
-theorem R.toTensor_length [hqgt1 : Fact (q > 1)] (a : R q n) : a.toTensor.length = a.repLength := by
-  unfold R.toTensor
-  unfold R.repLength
-  cases Polynomial.degree a.representative <;> simp
-
-
 theorem R.toTensor_getD [hqgt1 : Fact (q > 1)] (a : R q n) (i : Nat) : a.toTensor.getD i 0 = (a.coeff i).toInt := by
   simp [R.toTensor, R.coeff]
   have hLength : (List.map (fun i => ZMod.toInt q (Polynomial.coeff (R.representative q n a) i)) (List.range (R.repLength a))).length = repLength a := by
@@ -266,7 +260,8 @@ theorem toTensor_fromTensor_eq_trimTensor [hqgt1 : Fact (q > 1)] (a : R q n) (te
   rw [hTrim,R.trimTensor_append_zeroes_eq, R.fromTensor_eq_concat_zeroes, R.trimTensor_trimTensor]
   apply toTensor_fromTensor_trimTensor_eq_trimTensor _ _ hDeg hLen
 
-theorem fromTensor_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) : R.fromTensor a.toTensor = a := by
+/- TODO: this should be a theorem that we prove, that the length of anything that comes from `R.toTensor` will be < 2^n -/
+theorem fromTensor_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) (adeg : (R.representative q n a).natDegree + 1 < 2^n) : R.fromTensor a.toTensor = a := by
   cases h : Polynomial.degree (R.representative q n a) with
     | none =>
         have h' :=  Polynomial.degree_eq_bot.1 h
@@ -284,9 +279,11 @@ theorem fromTensor_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) : R.fromTensor a.
         rw [toTensor_fromTensor]
         rw[← ZMod.coe_int_cast]
         norm_cast
+        . simp [R.toTensor_length]
+          have hdeg := R.repLength_leq_representative_degree_plus_1 q n a
+          linarith
 
-theorem fromTensor_toTensor' [hqgt1 : Fact (q > 1)] (a : R q n) : R.fromTensor a.toTensor' = a := by
+theorem fromTensor_toTensor' [hqgt1 : Fact (q > 1)] (a : R q n) (adeg : (R.representative q n a).natDegree + 1 < 2^n) : R.fromTensor a.toTensor' = a := by
   rw [← R.fromTensor_eq_fromTensor_trimTensor, R.trim_toTensor'_eq_toTensor]
-  apply fromTensor_toTensor
-
+  apply fromTensor_toTensor a adeg
 end Poly

--- a/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
@@ -227,12 +227,11 @@ theorem R.trim_toTensor'_eq_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) :
   rw [R.trimTensor_toTensor'_eq_trimTensor_toTensor, toTensor_trimTensor_eq_toTensor]
 
 
-theorem toTensor_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int) (i : Nat):
+theorem toTensor_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int) (i : Nat) (htensorlen : List.length tensor < 2 ^ n):
   (R.fromTensor tensor (q:=q) (n :=n)).toTensor.getD i 0 = (tensor.getD i 0) % q := by
   simp[R.toTensor_getD]
-
   simp[ZMod.toInt];
-  simp[R.coeff_fromTensor]
+  rw[R.coeff_fromTensor (hqgt1 := hqgt1) (htensorlen := htensorlen)]
   norm_cast
   simp[Int.cast, ZMod.cast]
   cases q;


### PR DESCRIPTION
Goal: clear the `sorry`s for the definition of fromTensor. Pairing with @goens . 