### PR TITLE
Scf for fusion

### DIFF
--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -250,6 +250,16 @@ theorem Valuation.snoc_toSnoc {Γ : Ctxt Ty} {t t' : Ty} (s : Γ.Valuation) (x :
     (v : Γ.Var t') : (s.snoc x) v.toSnoc = s v := by
   simp [Ctxt.Valuation.snoc]
 
+/-!
+# Helper to simplify context manipulation with toSnoc and variable access.
+-/
+/--  (ctx.snoc v₁) ⟨n+1, _⟩ = ctx ⟨n, _⟩ -/
+@[simp]
+theorem Valuation.snoc_eval {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
+    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) (n+1) = some var_val) :
+    (V.snoc v) ⟨n+1, hvar⟩ = V ⟨n, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+  rfl
+
 /-- Make a a valuation for a singleton value -/
 def Valuation.singleton {t : Ty} (v : toType t) : Ctxt.Valuation [t] :=
   Ctxt.Valuation.nil.snoc v

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1244,16 +1244,17 @@ macro "simp_peephole" "[" ts: Lean.Parser.Tactic.simpLemma,* "]" "at" ll:ident :
         Ctxt.DerivedCtxt.ofCtxt_empty, Ctxt.Valuation.snoc_last,
         Com.denote, Expr.denote, HVector.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
         Ctxt.empty, Ctxt.empty_eq, Ctxt.snoc, Ctxt.Valuation.nil, Ctxt.Valuation.snoc_last,
-        Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
+        Ctxt.Valuation.snoc_eval, Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
         HVector.map, HVector.toPair, HVector.toTuple, OpDenote.denote, Expr.op_mk, Expr.args_mk,
         DialectMorphism.mapOp, DialectMorphism.mapTy, List.map, Ctxt.snoc, List.map,
+        Function.comp, Ctxt.Valuation.ofPair, Ctxt.Valuation.ofHVector, Function.uncurry,
         $ts,*]
-      generalize $ll { val := 0, property := _ } = a;
-      generalize $ll { val := 1, property := _ } = b;
-      generalize $ll { val := 2, property := _ } = c;
-      generalize $ll { val := 3, property := _ } = d;
-      generalize $ll { val := 4, property := _ } = e;
-      generalize $ll { val := 5, property := _ } = f;
+      try generalize $ll { val := 0, property := _ } = a;
+      try generalize $ll { val := 1, property := _ } = b;
+      try generalize $ll { val := 2, property := _ } = c;
+      try generalize $ll { val := 3, property := _ } = d;
+      try generalize $ll { val := 4, property := _ } = e;
+      try generalize $ll { val := 5, property := _ } = f;
       try simp (config := {decide := false}) [Goedel.toType] at a b c d e f;
       try clear f;
       try clear e;

--- a/SSA/Projects/Scf/Scf.lean
+++ b/SSA/Projects/Scf/Scf.lean
@@ -324,61 +324,14 @@ section ValuationVariableAccess
 
 /-- (ctx.snoc v₁) ⟨1, _⟩ = ctx ⟨0, _⟩ -/
 @[simp]
-theorem Ctxt.Valuation.snoc_eval_one {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 1 = some var_val) :
-    (V.snoc v) ⟨1, hvar⟩ = V ⟨0, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+theorem Ctxt.Valuation.snoc_eval {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
+    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) (n+1) = some var_val) :
+    (V.snoc v) ⟨n+1, hvar⟩ = V ⟨n, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
   rfl
 
-/-- (ctx.snoc v₁) ⟨2, _⟩ = ctx ⟨1, _⟩ -/
-@[simp]
-theorem Ctxt.Valuation.snoc_eval_two {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 2 = some var_val) :
-    (V.snoc v) ⟨2, hvar⟩ = V ⟨1, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
-  rfl
 
-/-- (ctx.snoc v₁) ⟨3, _⟩ = ctx ⟨2, _⟩ -/
-@[simp]
-theorem Ctxt.Valuation.snoc_eval_three {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 3 = some var_val) :
-    (V.snoc v) ⟨3, hvar⟩ = V ⟨2, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
-  rfl
-
-/-- (ctx.snoc v₁) ⟨4, _⟩ = ctx ⟨3, _⟩ -/
-@[simp]
-theorem Ctxt.Valuation.snoc_eval_four {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 4 = some var_val) :
-    (V.snoc v) ⟨4, hvar⟩ = V ⟨3, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
-  rfl
-
-/-- (ctx.snoc v₁) ⟨5, _⟩ = ctx ⟨4, _⟩ -/
-@[simp]
-theorem Ctxt.Valuation.snoc_eval_five {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 5 = some var_val) :
-    (V.snoc v) ⟨5, hvar⟩ = V ⟨4, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
-  rfl
-
-/-- (ctx.snoc v₁) ⟨6, _⟩ = ctx ⟨5, _⟩ -/
-@[simp]
-theorem Ctxt.Valuation.snoc_eval_six {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 6 = some var_val) :
-    (V.snoc v) ⟨6, hvar⟩ = V ⟨5, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
-  rfl
-
-/-- ((ctx.snoc v₁).snoc v₂) ⟨2, _⟩ = ctx ⟨0, _⟩ -/
-@[simp]
-theorem Ctxt.Valuation.snoc_snoc_eval_two {ty₁ ty₂: Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v₁ : ⟦ty₁⟧) (v₂ : ⟦ty₂⟧)
-    (hvar : Ctxt.get? ((Ctxt.snoc Γ ty₁).snoc ty₂) 2 = some var_val) :
-    ((V.snoc v₁).snoc v₂) ⟨2, hvar⟩ = V ⟨0, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
-  rfl
-
-/-- (((ctx.snoc v₁).snoc v₂).snoc v₃) ⟨3, _⟩ = ctx ⟨0, _⟩ -/
-@[simp]
-theorem Ctxt.Valuation.snoc_snoc_snoc_eval_three {ty₁ ty₂ ty₃: Ty} (Γ : Ctxt Ty) (V : Γ.Valuation)
-    (v₁ : ⟦ty₁⟧) (v₂ : ⟦ty₂⟧) (v₃ : ⟦ty₃⟧)
-    (hvar : Ctxt.get? (((Ctxt.snoc Γ ty₁).snoc ty₂).snoc ty₃) 3 = some var_val) :
-    (((V.snoc v₁).snoc v₂).snoc v₃) ⟨3, hvar⟩ = V ⟨0, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
-  rfl
 end ValuationVariableAccess
+
 /-# Repeatedly adding a constant in a loop is replaced with a multiplication.
 
 We keep the increment outside the loop so that we don't need to deal with creating and deleting tuples for the "for" region body,
@@ -501,13 +454,7 @@ theorem correct :
     Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
     HVector.map, HVector.toPair, HVector.toTuple, OpDenote.denote, Expr.op_mk, Expr.args_mk,
     neg,
-    Ctxt.Valuation.snoc_eval_one,
-    Ctxt.Valuation.snoc_eval_two,
-    Ctxt.Valuation.snoc_eval_three,
-    Ctxt.Valuation.snoc_eval_four,
-    Ctxt.Valuation.snoc_eval_five,
-    Ctxt.Valuation.snoc_eval_six,
-    Ctxt.Valuation.snoc_snoc_eval_two, Ctxt.Valuation.snoc_snoc_snoc_eval_three]
+    Ctxt.Valuation.snoc_eval]
     done
 
 #print axioms correct --  [propext, Classical.choice, Quot.sound]
@@ -560,7 +507,7 @@ theorem correct :
     HVector.map, HVector.toPair, HVector.toTuple, OpDenote.denote, Expr.op_mk, Expr.args_mk,
     Function.comp, Ctxt.Valuation.ofPair, Ctxt.Valuation.ofHVector, Function.uncurry,
     add, cst_nat,
-    Ctxt.Valuation.snoc_eval_one, Ctxt.Valuation.snoc_snoc_eval_two, Ctxt.Valuation.snoc_snoc_snoc_eval_three]
+    Ctxt.Valuation.snoc_eval]
     have swap_niters := add_comm (a := niters1) (b := niters2)
     have H : (LoopBody.CounterDecorator 1 fun i v =>
           Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters1 + niters2]

--- a/SSA/Projects/Scf/Scf.lean
+++ b/SSA/Projects/Scf/Scf.lean
@@ -108,7 +108,7 @@ end LoopBody
 
 namespace LoopBody.IndexInvariant
 
-/-- Evaluating a loop index invariant function is the same as evaluating it at Invariant -/
+/-- Evaluating a loop index invariant function is the same as evaluating it at `atZero` -/
 @[simp]
 theorem eval' {f : LoopBody t} (hf : LoopBody.IndexInvariant f) (i : Int) (v : t) :
   f i v = f.atZero v := by unfold LoopBody.IndexInvariant at hf; rw [LoopBody.atZero, hf]

--- a/SSA/Projects/Scf/Scf.lean
+++ b/SSA/Projects/Scf/Scf.lean
@@ -417,8 +417,43 @@ def rhs : Com Op [/- v0 -/ t] t :=
   Com.ret ⟨0, by simp[Ctxt.snoc]⟩
 #check rhs
 
+/-- (ctx.snoc v₁) ⟨1, _⟩ = ctx ⟨0, _⟩ -/
+@[simp]
+theorem Ctxt.Valuation.snoc_eval_one {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
+  (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 1 = some var_val) :
+  (V.snoc v) ⟨1, hvar⟩ = V ⟨0, by simp[Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+
+/-- ((ctx.snoc v₁).snoc v₂) ⟨2, _⟩ = ctx ⟨0, _⟩ -/
+@[simp]
+theorem Ctxt.Valuation.snoc_snoc_eval_two {ty₁ ty₂: Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v₁ : ⟦ty₁⟧) (v₂ : ⟦ty₂⟧)
+  (hvar : Ctxt.get? ((Ctxt.snoc Γ ty₁).snoc ty₂) 2 = some var_val) :
+  ((V.snoc v₁).snoc v₂) ⟨2, hvar⟩ = V ⟨0, by simp[Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+
+/-- (((ctx.snoc v₁).snoc v₂).snoc v₃) ⟨3, _⟩ = ctx ⟨0, _⟩ -/
+@[simp]
+theorem Ctxt.Valuation.snoc_snoc_snoc_eval_three {ty₁ ty₂ ty₃: Ty} (Γ : Ctxt Ty) (V : Γ.Valuation)
+  (v₁ : ⟦ty₁⟧) (v₂ : ⟦ty₂⟧) (v₃ : ⟦ty₃⟧)
+  (hvar : Ctxt.get? (((Ctxt.snoc Γ ty₁).snoc ty₂).snoc ty₃) 3 = some var_val) :
+  (((V.snoc v₁).snoc v₂).snoc v₃) ⟨3, hvar⟩ = V ⟨0, by simp[Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+
 theorem correct :
   Com.denote (lhs rgn niters1 ninters2 start1) Γv = Com.denote (rhs rgn niters1 ninters2 start1) Γv := by
+    simp[lhs, rhs, for_, axpy, cst]
+    try simp (config := {decide := false}) only [
+    Com.denote, Expr.denote, HVector.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
+    Ctxt.empty, Ctxt.empty_eq, Ctxt.snoc, Ctxt.Valuation.nil, Ctxt.Valuation.snoc_last,
+    Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
+    HVector.map, HVector.toPair, HVector.toTuple, OpDenote.denote, Expr.op_mk, Expr.args_mk,
+    Function.comp, Ctxt.Valuation.ofPair, Ctxt.Valuation.ofHVector, Function.uncurry,
+    add, cst_nat,
+    Ctxt.Valuation.snoc_eval_one, Ctxt.Valuation.snoc_snoc_eval_two, Ctxt.Valuation.snoc_snoc_snoc_eval_three]
+    have swap_niters := add_comm (a := niters1) (b := niters2)
+
+    simp[Function.iterate_add_apply]
+
+    generalize A:Γv { val := 0, property := _ } = a;
+    generalize B:Γv { val := 1, property := _ } = b;
+
     sorry -- TODO: finish proof
 
 -- TODO: add a PeepholeRewrite for this theorem.

--- a/SSA/Projects/Scf/Scf.lean
+++ b/SSA/Projects/Scf/Scf.lean
@@ -325,51 +325,59 @@ section ValuationVariableAccess
 /-- (ctx.snoc v₁) ⟨1, _⟩ = ctx ⟨0, _⟩ -/
 @[simp]
 theorem Ctxt.Valuation.snoc_eval_one {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-  (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 1 = some var_val) :
-  (V.snoc v) ⟨1, hvar⟩ = V ⟨0, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 1 = some var_val) :
+    (V.snoc v) ⟨1, hvar⟩ = V ⟨0, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+  rfl
 
 /-- (ctx.snoc v₁) ⟨2, _⟩ = ctx ⟨1, _⟩ -/
 @[simp]
 theorem Ctxt.Valuation.snoc_eval_two {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-  (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 2 = some var_val) :
-  (V.snoc v) ⟨2, hvar⟩ = V ⟨1, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 2 = some var_val) :
+    (V.snoc v) ⟨2, hvar⟩ = V ⟨1, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+  rfl
 
 /-- (ctx.snoc v₁) ⟨3, _⟩ = ctx ⟨2, _⟩ -/
 @[simp]
 theorem Ctxt.Valuation.snoc_eval_three {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-  (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 3 = some var_val) :
-  (V.snoc v) ⟨3, hvar⟩ = V ⟨2, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 3 = some var_val) :
+    (V.snoc v) ⟨3, hvar⟩ = V ⟨2, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+  rfl
 
 /-- (ctx.snoc v₁) ⟨4, _⟩ = ctx ⟨3, _⟩ -/
 @[simp]
 theorem Ctxt.Valuation.snoc_eval_four {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-  (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 4 = some var_val) :
-  (V.snoc v) ⟨4, hvar⟩ = V ⟨3, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 4 = some var_val) :
+    (V.snoc v) ⟨4, hvar⟩ = V ⟨3, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+  rfl
 
 /-- (ctx.snoc v₁) ⟨5, _⟩ = ctx ⟨4, _⟩ -/
 @[simp]
 theorem Ctxt.Valuation.snoc_eval_five {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-  (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 5 = some var_val) :
-  (V.snoc v) ⟨5, hvar⟩ = V ⟨4, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 5 = some var_val) :
+    (V.snoc v) ⟨5, hvar⟩ = V ⟨4, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+  rfl
 
 /-- (ctx.snoc v₁) ⟨6, _⟩ = ctx ⟨5, _⟩ -/
 @[simp]
 theorem Ctxt.Valuation.snoc_eval_six {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-  (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 6 = some var_val) :
-  (V.snoc v) ⟨6, hvar⟩ = V ⟨5, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) 6 = some var_val) :
+    (V.snoc v) ⟨6, hvar⟩ = V ⟨5, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+  rfl
 
 /-- ((ctx.snoc v₁).snoc v₂) ⟨2, _⟩ = ctx ⟨0, _⟩ -/
 @[simp]
 theorem Ctxt.Valuation.snoc_snoc_eval_two {ty₁ ty₂: Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v₁ : ⟦ty₁⟧) (v₂ : ⟦ty₂⟧)
-  (hvar : Ctxt.get? ((Ctxt.snoc Γ ty₁).snoc ty₂) 2 = some var_val) :
-  ((V.snoc v₁).snoc v₂) ⟨2, hvar⟩ = V ⟨0, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+    (hvar : Ctxt.get? ((Ctxt.snoc Γ ty₁).snoc ty₂) 2 = some var_val) :
+    ((V.snoc v₁).snoc v₂) ⟨2, hvar⟩ = V ⟨0, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+  rfl
 
 /-- (((ctx.snoc v₁).snoc v₂).snoc v₃) ⟨3, _⟩ = ctx ⟨0, _⟩ -/
 @[simp]
 theorem Ctxt.Valuation.snoc_snoc_snoc_eval_three {ty₁ ty₂ ty₃: Ty} (Γ : Ctxt Ty) (V : Γ.Valuation)
-  (v₁ : ⟦ty₁⟧) (v₂ : ⟦ty₂⟧) (v₃ : ⟦ty₃⟧)
-  (hvar : Ctxt.get? (((Ctxt.snoc Γ ty₁).snoc ty₂).snoc ty₃) 3 = some var_val) :
-  (((V.snoc v₁).snoc v₂).snoc v₃) ⟨3, hvar⟩ = V ⟨0, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ := rfl
+    (v₁ : ⟦ty₁⟧) (v₂ : ⟦ty₂⟧) (v₃ : ⟦ty₃⟧)
+    (hvar : Ctxt.get? (((Ctxt.snoc Γ ty₁).snoc ty₂).snoc ty₃) 3 = some var_val) :
+    (((V.snoc v₁).snoc v₂).snoc v₃) ⟨3, hvar⟩ = V ⟨0, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
+  rfl
 end ValuationVariableAccess
 /-# Repeatedly adding a constant in a loop is replaced with a multiplication.
 

--- a/SSA/Projects/Scf/Scf.lean
+++ b/SSA/Projects/Scf/Scf.lean
@@ -500,29 +500,30 @@ def rhs : Com Op [/- v0 -/ t] t :=
 theorem correct :
   Com.denote (lhs rgn niters1 niters2 start1) Γv = Com.denote (rhs rgn niters1 niters2 start1) Γv := by
     simp [lhs, rhs, for_, axpy, cst]
-    try simp (config := {decide := false}) only [
+    try simp_peephole [add, iterate, for_, axpy, cst,
     Com.denote, Expr.denote, HVector.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
     Ctxt.empty, Ctxt.empty_eq, Ctxt.snoc, Ctxt.Valuation.nil, Ctxt.Valuation.snoc_last,
     Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
     HVector.map, HVector.toPair, HVector.toTuple, OpDenote.denote, Expr.op_mk, Expr.args_mk,
     Function.comp, Ctxt.Valuation.ofPair, Ctxt.Valuation.ofHVector, Function.uncurry,
     add, cst_nat,
-    Ctxt.Valuation.snoc_eval]
+    Ctxt.Valuation.snoc_eval] at Γv
+    intros a
     have swap_niters := add_comm (a := niters1) (b := niters2)
+    set arg := ((LoopBody.CounterDecorator 1 fun i v =>
+                  Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters1]
+              (start1, a)).2
     have H : (LoopBody.CounterDecorator 1 fun i v =>
           Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters1 + niters2]
-      (start1, Γv (Var.last [] t)) = (LoopBody.CounterDecorator 1 fun i v =>
+      (start1, a) = (LoopBody.CounterDecorator 1 fun i v =>
           Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters2 + niters1]
-      (start1, Γv (Var.last [] t)) := by
+      (start1, a) := by
         congr
-    simp [H]
-    simp [Function.iterate_add_apply]
+    rw [H]
+    repeat rw [Function.iterate_add_apply]
     congr
     rw [LoopBody.CounterDecorator.iterate_fst_val]
     linarith
-    done
-
--- TODO: add a PeepholeRewrite for this theorem.
 
 end ForFusion
 

--- a/SSA/Projects/Scf/Scf.lean
+++ b/SSA/Projects/Scf/Scf.lean
@@ -111,7 +111,8 @@ namespace LoopBody.IndexInvariant
 /-- Evaluating a loop index invariant function is the same as evaluating it at `atZero` -/
 @[simp]
 theorem eval' {f : LoopBody t} (hf : LoopBody.IndexInvariant f) (i : Int) (v : t) :
-  f i v = f.atZero v := by unfold LoopBody.IndexInvariant at hf; rw [LoopBody.atZero, hf]
+    f i v = f.atZero v := by 
+  unfold LoopBody.IndexInvariant at hf; rw [LoopBody.atZero, hf]
 
 /-- iterating a loop invariant function gives a well understood answer: the iterates of the function. -/
 @[simp]

--- a/SSA/Projects/Scf/Scf.lean
+++ b/SSA/Projects/Scf/Scf.lean
@@ -1,11 +1,17 @@
 import Mathlib.Logic.Function.Iterate
 import SSA.Core.Framework
+import SSA.Core.ErasedContext
 import SSA.Core.Util
 set_option pp.proofs false
 set_option pp.proofs.withType false
 
 open Std (BitVec)
 open Ctxt(Var)
+
+/- disable proofs and types of proofs from showing to make proof states legible -/
+set_option pp.proofs false
+set_option pp.proofs.withType false
+
 
 namespace ScfRegion
 
@@ -313,24 +319,6 @@ theorem for_return {t : Ty} (istart istep: Var Γ .int) (niters : Var Γ .nat) (
     simp_peephole at Γv
     simp [Com.denote]
     rw [LoopBody.CounterDecorator.constant_iterate]
-
-set_option pp.proofs false
-set_option pp.proofs.withType false
-
-/-!
-# Helpers for simplifying context manipulation with toSnoc and variable access
--/
-section ValuationVariableAccess
-
-/-- (ctx.snoc v₁) ⟨1, _⟩ = ctx ⟨0, _⟩ -/
-@[simp]
-theorem Ctxt.Valuation.snoc_eval {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) (n+1) = some var_val) :
-    (V.snoc v) ⟨n+1, hvar⟩ = V ⟨n, by simp [Ctxt.get?,Ctxt.snoc] at hvar; exact hvar⟩ :=
-  rfl
-
-
-end ValuationVariableAccess
 
 /-# Repeatedly adding a constant in a loop is replaced with a multiplication.
 

--- a/SSA/Projects/Scf/Scf.lean
+++ b/SSA/Projects/Scf/Scf.lean
@@ -94,15 +94,15 @@ def atZero (f : LoopBody t) : t → t := fun v => f 0 v
 /-- If there exists a function `g : t → t` which agrees with `f`, then `f` is loop index invariant. -/
 theorem eq_invariant_fn
     (f : LoopBody t) (g : t → t) (hf : ∀ (i : Int) (v : t), f i v = g v) :
-    LoopBody.IndexInvariant f /\ atZero f = g:= by
-      apply And.intro
-      case left =>
-        intros i j v
-        rw [hf i v, hf j v]
-      case right =>
-        simp [atZero]
-        funext v
-        rw [hf 0 v]
+    LoopBody.IndexInvariant f ∧ atZero f = g:= by
+  apply And.intro
+  case left =>
+    intros i j v
+    rw [hf i v, hf j v]
+  case right =>
+    simp [atZero]
+    funext v
+    rw [hf 0 v]
 
 end LoopBody
 
@@ -116,26 +116,34 @@ theorem eval' {f : LoopBody t} (hf : LoopBody.IndexInvariant f) (i : Int) (v : t
 
 /-- iterating a loop invariant function gives a well understood answer: the iterates of the function. -/
 @[simp]
-theorem iterate {f : LoopBody t} (hf : LoopBody.IndexInvariant f) (δ : Int)  (i₀ : Int) (v₀ : t) (k : ℕ) :
-  (f.CounterDecorator δ)^[k] (i₀, v₀) = (i₀ + δ * k, (f.atZero)^[k] v₀) := by
-    induction k generalizing i₀ v₀
-    case zero => simp
-    case succ i hi =>
-      simp
-      rw [hi]
-      simp [LoopBody.CounterDecorator]
-      simp [eval' hf]
-      linarith
+theorem iterate {f : LoopBody t}
+    (hf : LoopBody.IndexInvariant f)
+    (δ : Int)
+    (i₀ : Int)
+    (v₀ : t) (k : ℕ) :
+    (f.CounterDecorator δ)^[k] (i₀, v₀) = (i₀ + δ * k, (f.atZero)^[k] v₀) := by
+  induction k generalizing i₀ v₀
+  case zero => simp
+  case succ i hi =>
+    simp
+    rw [hi]
+    simp [LoopBody.CounterDecorator]
+    simp [eval' hf]
+    linarith
 
 /-- the first component of iterating a loop invariant function -/
 @[simp]
-theorem iterate_fst {f : LoopBody t} (δ : Int) (hf : f.IndexInvariant) (i₀ : Int) (v₀ : t) (k : ℕ) :
-  ((f.CounterDecorator δ)^[k] (i₀, v₀)).1 = i₀ + δ * k := by simp [hf];
+theorem iterate_fst {f : LoopBody t}
+    (δ : Int) (hf : f.IndexInvariant) (i₀ : Int) (v₀ : t) (k : ℕ) :
+    ((f.CounterDecorator δ)^[k] (i₀, v₀)).1 = i₀ + δ * k := by
+  simp [hf];
 
 /-- the second component of iterating a loop invariant function -/
 @[simp]
-theorem iterate_snd {f : LoopBody t} (δ : Int) (hf : f.IndexInvariant) (i₀ : Int) (v₀ : t) (k : ℕ) :
-  ((f.CounterDecorator δ)^[k] (i₀, v₀)).2 = (f.atZero)^[k] v₀ := by simp [hf]
+theorem iterate_snd {f : LoopBody t}
+    (δ : Int) (hf : f.IndexInvariant) (i₀ : Int) (v₀ : t) (k : ℕ) :
+    ((f.CounterDecorator δ)^[k] (i₀, v₀)).2 = (f.atZero)^[k] v₀ := by
+  simp [hf]
 
 end LoopBody.IndexInvariant
 
@@ -143,26 +151,26 @@ namespace LoopBody.CounterDecorator
 /-- iterated value of the fst of the tuple of CounterDecorator (ie, the loop counter) -/
 @[simp]
 theorem iterate_fst_val (δ: Int) (f : LoopBody α) (i₀ : Int) (v₀ : α) (k : ℕ) :
-  ((f.CounterDecorator δ)^[k] (i₀, v₀)).1 = i₀ + k * δ := by
-    induction k generalizing i₀ v₀
-    case zero => simp
-    case succ i hi =>
-      simp
-      rw [hi]
-      simp [LoopBody.CounterDecorator]
-      linarith
+    ((f.CounterDecorator δ)^[k] (i₀, v₀)).1 = i₀ + k * δ := by
+  induction k generalizing i₀ v₀
+  case zero => simp
+  case succ i hi =>
+    simp
+    rw [hi]
+    simp [LoopBody.CounterDecorator]
+    linarith
 
 /-- evaluating a function that does not access the index (const_index_fn) -/
 theorem const_index_fn_eval
-  (δ : Int) (i : Int) (vstart : α) (f : LoopBody α) (f' : α → α) (hf : f = fun i a => f' a) :
-  (f.CounterDecorator δ) (i, vstart) = (i + δ, f' vstart) := by
+    (δ : Int) (i : Int) (vstart : α) (f : LoopBody α) (f' : α → α) (hf : f = fun i a => f' a) :
+    (f.CounterDecorator δ) (i, vstart) = (i + δ, f' vstart) := by
   simp [LoopBody.CounterDecorator, hf]
 
 
 /-- iterating a function that does not access the index (const_index_fn) -/
-theorem const_index_fn_iterate
-  (δ : Int) (i : Int) (vstart : α) (f : LoopBody α) (f' : α → α) (hf : f = fun i a => f' a) (k : ℕ) :
-  (f.CounterDecorator δ)^[k] (i, vstart) = (i + k * δ, f'^[k] vstart) := by
+theorem const_index_fn_iterate (δ : Int)
+    (i : Int) (vstart : α) (f : LoopBody α) (f' : α → α) (hf : f = fun i a => f' a) (k : ℕ) :
+    (f.CounterDecorator δ)^[k] (i, vstart) = (i + k * δ, f'^[k] vstart) := by
   obtain ⟨hf, hf'⟩ := f.eq_invariant_fn f' (by intros i v; rw [hf])
   rw [IndexInvariant.iterate hf]; simp
   apply And.intro
@@ -172,26 +180,25 @@ theorem const_index_fn_iterate
 /-- CounterDecorator on a constant function -/
 @[simp]
 theorem constant (δ : Int) (i : Int) (vstart : α) :
-  (LoopBody.CounterDecorator δ fun _i v => v) (i, vstart) = (i + δ, vstart) := rfl
+    (LoopBody.CounterDecorator δ fun _i v => v) (i, vstart) = (i + δ, vstart) := rfl
 
 /-- iterate the CounterDecorator of a constant function. -/
-theorem constant_iterate {α : Type} (k : ℕ) (δ : Int):
-  ((LoopBody.CounterDecorator δ (fun (i : Int) (v : α) => v))^[k]) = fun (args : ℤ × α) => (args.fst + k * δ, args.snd) := by {
-    funext ⟨i, v⟩
-    induction k generalizing i v
-    case h.zero =>
-      simp
-    case h.succ n ihn =>
-      simp [ihn]
-      linarith
-  }
+theorem constant_iterate {α : Type} (k : ℕ) (δ : Int) :
+    ((LoopBody.CounterDecorator δ (fun (i : Int) (v : α) => v))^[k]) = 
+    fun (args : ℤ × α) => (args.fst + k * δ, args.snd) := by 
+  funext ⟨i, v⟩
+  induction k generalizing i v
+  case h.zero =>
+    simp
+  case h.succ n ihn =>
+    simp [ihn]
+    linarith
 
 def to_loop_run (δ : Int) (f : LoopBody α) (niters : ℕ) (val : α) : α :=
   (LoopBody.CounterDecorator δ f (niters,val)).2
 
 end LoopBody.CounterDecorator
 
-#check Prod.mk
 @[reducible]
 noncomputable instance : OpDenote Op Ty where
   denote
@@ -361,8 +368,8 @@ def rhs (vincrement : ℤ) : Com Op [/- nsteps -/ .nat, /- vstart -/ .int] .int 
   Com.ret ⟨0, by simp [Ctxt.snoc]⟩
 
 /-- iterated addition-/
-theorem add_iterate (v0 : Int) (b : Int) (a : ℕ):
-  (fun v => v0 + v)^[a] b = v0 * ↑a + b := by
+theorem add_iterate (v0 : Int) (b : Int) (a : ℕ) :
+    (fun v => v0 + v)^[a] b = v0 * ↑a + b := by
   induction a generalizing b v0
   case zero => simp
   case succ a' ah =>
@@ -371,13 +378,13 @@ theorem add_iterate (v0 : Int) (b : Int) (a : ℕ):
 
 /-- Reverse a loop. -/
 theorem correct :
-  Com.denote (lhs v0) Γv = Com.denote (rhs v0) Γv := by
-    simp [lhs, rhs, for_, axpy, cst]
-    try simp_peephole [add, iterate, for_, axpy, cst, cst_nat] at Γv
-    intros A B
-    rw [LoopBody.CounterDecorator.const_index_fn_iterate]
-    case hf => rfl
-    simp; apply add_iterate
+    Com.denote (lhs v0) Γv = Com.denote (rhs v0) Γv := by
+  simp [lhs, rhs, for_, axpy, cst]
+  try simp_peephole [add, iterate, for_, axpy, cst, cst_nat] at Γv
+  intros A B
+  rw [LoopBody.CounterDecorator.const_index_fn_iterate]
+  case hf => rfl
+  simp; apply add_iterate
 #print axioms correct --  [propext, Classical.choice, Quot.sound]
 
 -- TODO: add a PeepholeRewrite for this theorem.
@@ -417,17 +424,16 @@ def rhs : Com Op [/- start-/ .int, /- delta -/.int, /- steps -/ .nat, /- v0 -/ t
 /-- rewrite a variable whose index is '> 0' to a new variable which is the 'snoc' of a smaller variable.
   this enables rewriting with `Ctxt.Valuation.snoc_toSnoc`. -/
 theorem Ctxt.Var.toSnoc (ty snocty : Ty) (Γ : Ctxt Ty)  (V : Ctxt.Valuation Γ) {snocval : ⟦snocty⟧}
-  {v: ℕ}
-  {hvproof : Ctxt.get? Γ v = some ty}
-  {var : Γ.Var ty}
-  (hvar : var = ⟨v, hvproof⟩) :
-  V var = (Ctxt.Valuation.snoc V snocval) ⟨v+1, by simp [Ctxt.snoc] at hvproof; simp [Ctxt.snoc, hvproof]⟩ := by
-    simp [Ctxt.Valuation.snoc, hvar]
+    {v: ℕ}
+    {hvproof : Ctxt.get? Γ v = some ty}
+    {var : Γ.Var ty}
+    (hvar : var = ⟨v, hvproof⟩) :
+    V var = (Ctxt.Valuation.snoc V snocval) ⟨v+1, by simp [Ctxt.snoc] at hvproof; simp [Ctxt.snoc, hvproof]⟩ := by
+  simp [Ctxt.Valuation.snoc, hvar]
 
-theorem correct :
-  Com.denote (lhs rgn) Γv = Com.denote (rhs rgn) Γv := by
-    simp [lhs, rhs, for_, axpy]
-    simp_peephole at Γv
+theorem correct : Com.denote (lhs rgn) Γv = Com.denote (rhs rgn) Γv := by
+  simp [lhs, rhs, for_, axpy]
+  simp_peephole at Γv
 
 #print axioms correct --  [propext, Classical.choice, Quot.sound]
 
@@ -470,24 +476,24 @@ def rhs : Com Op [/- v0 -/ t] t :=
 
 
 theorem correct :
-  Com.denote (lhs rgn niters1 niters2 start1) Γv = Com.denote (rhs rgn niters1 niters2 start1) Γv := by
-    simp [lhs, rhs, for_, axpy, cst]
-    try simp_peephole [add, iterate, for_, axpy, cst, cst_nat] at Γv
-    intros a
-    have swap_niters := add_comm (a := niters1) (b := niters2)
-    set arg := ((LoopBody.CounterDecorator 1 fun i v =>
-                  Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters1]
-              (start1, a)).2
-    have H : (LoopBody.CounterDecorator 1 fun i v =>
-          Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters1 + niters2]
-      (start1, a) = (LoopBody.CounterDecorator 1 fun i v =>
-          Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters2 + niters1]
-      (start1, a) := by
-        congr
-    rw [H, Function.iterate_add_apply]
-    congr
-    rw [LoopBody.CounterDecorator.iterate_fst_val]
-    linarith
+    Com.denote (lhs rgn niters1 niters2 start1) Γv = Com.denote (rhs rgn niters1 niters2 start1) Γv := by
+  simp [lhs, rhs, for_, axpy, cst]
+  try simp_peephole [add, iterate, for_, axpy, cst, cst_nat] at Γv
+  intros a
+  have swap_niters := add_comm (a := niters1) (b := niters2)
+  set arg := ((LoopBody.CounterDecorator 1 fun i v =>
+                Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters1]
+            (start1, a)).2
+  have H : (LoopBody.CounterDecorator 1 fun i v =>
+        Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters1 + niters2]
+    (start1, a) = (LoopBody.CounterDecorator 1 fun i v =>
+        Com.denote rgn (Ctxt.Valuation.snoc (Ctxt.Valuation.snoc default v) i))^[niters2 + niters1]
+    (start1, a) := by
+      congr
+  rw [H, Function.iterate_add_apply]
+  congr
+  rw [LoopBody.CounterDecorator.iterate_fst_val]
+  linarith
 
 end ForFusion
 


### PR DESCRIPTION
Adjacent for loops can be fused, assuming that the second loop ends where the first one starts.