### PR TITLE
Correctness proof for fuel gated peephole rewrite applier 

### DIFF
--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1214,6 +1214,23 @@ def rewritePeephole (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (target : Com Op
     (Com Op Γ₂ t₂) := rewritePeephole_go fuel pr 0 target
 end SimpPeepholeApplier
 
+/- repeatedly apply peephole on program. -/
+section SimpPeepholeApplier
+
+/-- rewrite with `pr` to `target` program, at location `ix` and later, running at most `fuel` steps. -/
+def rewritePeephole_go (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (ix : ℕ) (target : Com Op Γ₂ t₂) :
+    (Com Op Γ₂ t₂) := 
+  match fuel with
+  | 0 => target
+  | fuel' + 1 => 
+     let target' := rewritePeepholeAt pr ix target
+     rewritePeephole_go fuel' pr (ix + 1) target'
+
+/-- rewrite with `pr` to `target` program, running at most `fuel` steps. -/
+def rewritePeephole (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (target : Com Op Γ₂ t₂) :
+    (Com Op Γ₂ t₂) := rewritePeephole_go fuel pr 0 target
+end SimpPeepholeApplier
+
 /--
 `simp_peephole [t1, t2, ... tn]` at Γ simplifies the evaluation of the context Γ,
 leaving behind a bare Lean level proposition to be proven.

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1226,9 +1226,25 @@ def rewritePeephole_go (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (ix : ℕ) (t
      let target' := rewritePeepholeAt pr ix target
      rewritePeephole_go fuel' pr (ix + 1) target'
 
+/-- `rewritePeephole_go` preserve semantics -/
+theorem denote_rewritePeephole_go (pr : PeepholeRewrite Op Γ t)
+    (pos : ℕ) (target : Com Op Γ₂ t₂) :
+    (rewritePeephole_go fuel pr pos target).denote = target.denote := by
+      induction fuel generalizing pr pos target
+      case zero => simp[rewritePeephole_go, denote_rewritePeepholeAt]
+      case succ fuel' hfuel => 
+        simp[rewritePeephole_go, denote_rewritePeepholeAt, hfuel]
+
 /-- rewrite with `pr` to `target` program, running at most `fuel` steps. -/
 def rewritePeephole (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (target : Com Op Γ₂ t₂) :
     (Com Op Γ₂ t₂) := rewritePeephole_go fuel pr 0 target
+
+
+/-- `rewritePeephole` preserves semantics. -/
+theorem denote_rewritePeephole (fuel : ℕ)
+  (pr : PeepholeRewrite Op Γ t) (target : Com Op Γ₂ t₂) :
+    (rewritePeephole fuel pr target).denote = target.denote := by
+        simp[rewritePeephole, denote_rewritePeephole_go]
 end SimpPeepholeApplier
 
 /--

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1212,19 +1212,6 @@ def rewritePeephole_go (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (ix : ℕ) (t
 /-- rewrite with `pr` to `target` program, running at most `fuel` steps. -/
 def rewritePeephole (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (target : Com Op Γ₂ t₂) :
     (Com Op Γ₂ t₂) := rewritePeephole_go fuel pr 0 target
-end SimpPeepholeApplier
-
-/- repeatedly apply peephole on program. -/
-section SimpPeepholeApplier
-
-/-- rewrite with `pr` to `target` program, at location `ix` and later, running at most `fuel` steps. -/
-def rewritePeephole_go (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (ix : ℕ) (target : Com Op Γ₂ t₂) :
-    (Com Op Γ₂ t₂) := 
-  match fuel with
-  | 0 => target
-  | fuel' + 1 => 
-     let target' := rewritePeepholeAt pr ix target
-     rewritePeephole_go fuel' pr (ix + 1) target'
 
 /-- `rewritePeephole_go` preserve semantics -/
 theorem denote_rewritePeephole_go (pr : PeepholeRewrite Op Γ t)
@@ -1234,11 +1221,6 @@ theorem denote_rewritePeephole_go (pr : PeepholeRewrite Op Γ t)
       case zero => simp[rewritePeephole_go, denote_rewritePeepholeAt]
       case succ fuel' hfuel => 
         simp[rewritePeephole_go, denote_rewritePeepholeAt, hfuel]
-
-/-- rewrite with `pr` to `target` program, running at most `fuel` steps. -/
-def rewritePeephole (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (target : Com Op Γ₂ t₂) :
-    (Com Op Γ₂ t₂) := rewritePeephole_go fuel pr 0 target
-
 
 /-- `rewritePeephole` preserves semantics. -/
 theorem denote_rewritePeephole (fuel : ℕ)

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1201,8 +1201,8 @@ section SimpPeephole
 section SimpPeepholeApplier
 
 /-- rewrite with `pr` to `target` program, at location `ix` and later, running at most `fuel` steps. -/
-def rewritePeephole_go (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (ix : ℕ) (target : Com Op Γ₂ t₂) :
-    (Com Op Γ₂ t₂) := 
+def rewritePeephole_go (fuel : ℕ) (pr : PeepholeRewrite Op Γ t)
+    (ix : ℕ) (target : Com Op Γ₂ t₂) : (Com Op Γ₂ t₂) := 
   match fuel with
   | 0 => target
   | fuel' + 1 => 
@@ -1210,23 +1210,25 @@ def rewritePeephole_go (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (ix : ℕ) (t
      rewritePeephole_go fuel' pr (ix + 1) target'
 
 /-- rewrite with `pr` to `target` program, running at most `fuel` steps. -/
-def rewritePeephole (fuel : ℕ) (pr : PeepholeRewrite Op Γ t) (target : Com Op Γ₂ t₂) :
-    (Com Op Γ₂ t₂) := rewritePeephole_go fuel pr 0 target
+def rewritePeephole (fuel : ℕ)
+    (pr : PeepholeRewrite Op Γ t) (target : Com Op Γ₂ t₂) : (Com Op Γ₂ t₂) := 
+  rewritePeephole_go fuel pr 0 target
 
 /-- `rewritePeephole_go` preserve semantics -/
 theorem denote_rewritePeephole_go (pr : PeepholeRewrite Op Γ t)
     (pos : ℕ) (target : Com Op Γ₂ t₂) :
     (rewritePeephole_go fuel pr pos target).denote = target.denote := by
-      induction fuel generalizing pr pos target
-      case zero => simp[rewritePeephole_go, denote_rewritePeepholeAt]
-      case succ fuel' hfuel => 
-        simp[rewritePeephole_go, denote_rewritePeepholeAt, hfuel]
+  induction fuel generalizing pr pos target
+  case zero => 
+    simp[rewritePeephole_go, denote_rewritePeepholeAt]
+  case succ fuel' hfuel => 
+    simp[rewritePeephole_go, denote_rewritePeepholeAt, hfuel]
 
 /-- `rewritePeephole` preserves semantics. -/
 theorem denote_rewritePeephole (fuel : ℕ)
-  (pr : PeepholeRewrite Op Γ t) (target : Com Op Γ₂ t₂) :
+    (pr : PeepholeRewrite Op Γ t) (target : Com Op Γ₂ t₂) :
     (rewritePeephole fuel pr target).denote = target.denote := by
-        simp[rewritePeephole, denote_rewritePeephole_go]
+  simp[rewritePeephole, denote_rewritePeephole_go]
 end SimpPeepholeApplier
 
 /--


### PR DESCRIPTION


Recall that the peephole applier tries to apply the rewrite at each program location. It uses fuel to ensure that it always terminates. This models the API that we present in the paper. 

This PR fixes the formatting of this hastily written piece of code.
This also adds the (simple) proof that the peephole applier preserves semantics, which it must, as it is built upon the lower level peephole `rewritePeepholeAt`. 