### PR TITLE
Edsl cleanup refactor

### DIFF
--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -66,29 +66,103 @@ instance : Repr (BitVec n) where
   reprPrec
     | v, n => reprPrec (BitVec.toInt v) n
 
+/-- Homogeneous, unary operations -/
+inductive MOp.UnaryOp : Type
+  | neg
+  | not
+  | copy
+deriving Repr, DecidableEq, Inhabited
+
+/-- Homogeneous, binary operations -/
+inductive MOp.BinaryOp : Type
+  | and
+  | or
+  | xor
+  | shl
+  | lshr
+  | ashr
+  | urem
+  | srem
+  | add
+  | mul
+  | sub
+  | sdiv
+  | udiv
+deriving Repr, DecidableEq, Inhabited
+
 -- See: https://releases.llvm.org/14.0.0/docs/LangRef.html#bitwise-binary-operations
 inductive MOp (φ : Nat) : Type
-  | and     (w : Width φ) : MOp φ
-  | or      (w : Width φ) : MOp φ
-  | not     (w : Width φ) : MOp φ
-  | xor     (w : Width φ) : MOp φ
-  | shl     (w : Width φ) : MOp φ
-  | lshr    (w : Width φ) : MOp φ
-  | ashr    (w : Width φ) : MOp φ
-  | urem    (w : Width φ) : MOp φ
-  | srem    (w : Width φ) : MOp φ
+  | unary   (w : Width φ) (op : MOp.UnaryOp) :  MOp φ
+  | binary  (w : Width φ) (op : MOp.BinaryOp) :  MOp φ
   | select  (w : Width φ) : MOp φ
-  | add     (w : Width φ) : MOp φ
-  | mul     (w : Width φ) : MOp φ
-  | sub     (w : Width φ) : MOp φ
-  | neg     (w : Width φ) : MOp φ
-  | copy    (w : Width φ) : MOp φ
-  | sdiv    (w : Width φ) : MOp φ
-  | udiv    (w : Width φ) : MOp φ
   | icmp    (c : IntPredicate) (w : Width φ) : MOp φ
   /-- Since the width of the const might not be known, we just store the value as an `Int` -/
   | const (w : Width φ) (val : ℤ) : MOp φ
 deriving Repr, DecidableEq, Inhabited
+
+namespace MOp
+
+@[match_pattern] def neg    (w : Width φ) : MOp φ := .unary w .neg
+@[match_pattern] def not    (w : Width φ) : MOp φ := .unary w .not
+@[match_pattern] def copy   (w : Width φ) : MOp φ := .unary w .copy
+
+@[match_pattern] def and    (w : Width φ) : MOp φ := .binary w .and
+@[match_pattern] def or     (w : Width φ) : MOp φ := .binary w .or
+@[match_pattern] def xor    (w : Width φ) : MOp φ := .binary w .xor
+@[match_pattern] def shl    (w : Width φ) : MOp φ := .binary w .shl
+@[match_pattern] def lshr   (w : Width φ) : MOp φ := .binary w .lshr
+@[match_pattern] def ashr   (w : Width φ) : MOp φ := .binary w .ashr
+@[match_pattern] def urem   (w : Width φ) : MOp φ := .binary w .urem
+@[match_pattern] def srem   (w : Width φ) : MOp φ := .binary w .srem
+@[match_pattern] def add    (w : Width φ) : MOp φ := .binary w .add
+@[match_pattern] def mul    (w : Width φ) : MOp φ := .binary w .mul
+@[match_pattern] def sub    (w : Width φ) : MOp φ := .binary w .sub
+@[match_pattern] def sdiv   (w : Width φ) : MOp φ := .binary w .sdiv
+@[match_pattern] def udiv   (w : Width φ) : MOp φ := .binary w .udiv
+
+/-- Recursion principle in terms of individual operations, rather than `unary` or `binary` -/
+def deepCasesOn {motive : ∀ {φ}, MOp φ → Sort*}
+    (neg  : ∀ {φ} {w : Width φ}, motive (neg  w))
+    (not  : ∀ {φ} {w : Width φ}, motive (not  w))
+    (copy : ∀ {φ} {w : Width φ}, motive (copy w))
+    (and  : ∀ {φ} {w : Width φ}, motive (and  w))
+    (or   : ∀ {φ} {w : Width φ}, motive (or   w))
+    (xor  : ∀ {φ} {w : Width φ}, motive (xor  w))
+    (shl  : ∀ {φ} {w : Width φ}, motive (shl  w))
+    (lshr : ∀ {φ} {w : Width φ}, motive (lshr w))
+    (ashr : ∀ {φ} {w : Width φ}, motive (ashr w))
+    (urem : ∀ {φ} {w : Width φ}, motive (urem w))
+    (srem : ∀ {φ} {w : Width φ}, motive (srem w))
+    (add  : ∀ {φ} {w : Width φ}, motive (add  w))
+    (mul  : ∀ {φ} {w : Width φ}, motive (mul  w))
+    (sub  : ∀ {φ} {w : Width φ}, motive (sub  w))
+    (sdiv : ∀ {φ} {w : Width φ}, motive (sdiv w))
+    (udiv : ∀ {φ} {w : Width φ}, motive (udiv w))
+    (select : ∀ {φ} {w : Width φ}, motive (select w))
+    (icmp   : ∀ {φ c} {w : Width φ}, motive (icmp c w))
+    (const  : ∀ {φ v} {w : Width φ}, motive (const w v)) :
+    ∀ {φ} (op : MOp φ), motive op
+  | _, .neg _   => neg
+  | _, .not _   => not
+  | _, .copy _  => copy
+  | _, .and _   => and
+  | _, .or _    => or
+  | _, .xor _   => xor
+  | _, .shl _   => shl
+  | _, .lshr _  => lshr
+  | _, .ashr _  => ashr
+  | _, .urem _  => urem
+  | _, .srem _  => srem
+  | _, .add  _  => add
+  | _, .mul  _  => mul
+  | _, .sub  _  => sub
+  | _, .sdiv _  => sdiv
+  | _, .udiv _  => udiv
+  | _, .select _  => select
+  | _, .icmp ..   => icmp
+  | _, .const ..  => const
+
+end MOp
 
 instance : ToString (MOp φ) where
   toString
@@ -144,23 +218,17 @@ instance : ToString Op where
 
 @[simp, reducible]
 def MOp.sig : MOp φ → List (MTy φ)
-| .and w | .or w | .xor w | .shl w | .lshr w | .ashr w
-| .add w | .mul w | .sub w | .udiv w | .sdiv w
-| .srem w | .urem w | .icmp _ w =>
+| .binary w _ | .icmp _ w =>
   [.bitvec w, .bitvec w]
-| .not w | .neg w | .copy w => [.bitvec w]
+| .unary w _ => [.bitvec w]
 | .select w => [.bitvec 1, .bitvec w, .bitvec w]
 | .const _ _ => []
 
 @[simp, reducible]
 def MOp.outTy : MOp φ → MTy φ
-| .and w | .or w | .not w | .xor w | .shl w | .lshr w | .ashr w
-| .sub w |  .select w | .neg w | .copy w =>
-  .bitvec w
-| .add w | .mul w |  .sdiv w | .udiv w | .srem w | .urem w =>
+| .binary w _ | .unary w _ | .select w | .const w _ =>
   .bitvec w
 | .icmp _ _ => .bitvec 1
-| .const width _ => .bitvec width
 
 instance : OpSignature (MOp φ) (MTy φ) where
   signature op := ⟨op.sig, [], op.outTy⟩
@@ -186,7 +254,7 @@ def Op.denote (o : Op) (arg : HVector Goedel.toType (OpSignature.sig o)) :
   | Op.not _ => Option.map (~~~.) arg.toSingle
   | Op.copy _ => arg.toSingle
   | Op.neg _ => Option.map (-.) arg.toSingle
-  | Op.select _ => 
+  | Op.select _ =>
     let (ocond, otrue, ofalse) := arg.toTriple
     select? ocond otrue ofalse
   | Op.icmp c _ => pairBind (icmp? c) arg.toPair

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -190,6 +190,9 @@ abbrev Op := MOp 0
 
 namespace Op
 
+@[match_pattern] abbrev unary   (w : Nat) (op : MOp.UnaryOp)  : Op := MOp.unary (.concrete w) op
+@[match_pattern] abbrev binary  (w : Nat) (op : MOp.BinaryOp) : Op := MOp.binary (.concrete w) op
+
 @[match_pattern] abbrev and    : Nat → Op := MOp.and    ∘ .concrete
 @[match_pattern] abbrev or     : Nat → Op := MOp.or     ∘ .concrete
 @[match_pattern] abbrev not    : Nat → Op := MOp.not    ∘ .concrete

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -18,138 +18,24 @@ def mkUnaryOp {Γ : Ctxt (MTy φ)} {ty : (MTy φ)} (op : MOp φ)
   match ty with
   | .bitvec w =>
     match op with
-    -- Can't use a single arm, Lean won't write the rhs accordingly
-    | .neg w' => if h : w = w'
+    | .unary w' op => if h : w = w'
       then return ⟨
-        .neg w',
+        .unary w' op,
         by simp [OpSignature.outTy, signature, h],
         .cons (h ▸ e) .nil,
         .nil
       ⟩
       else throw <| .widthError w w'
-    | .not w' => if h : w = w'
-      then return ⟨
-        .not w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e) .nil,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-    | .copy w' => if h : w = w'
-      then return ⟨
-        .copy w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e) .nil,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-    | _ => throw <| .unsupportedUnaryOp
+      | _ => throw .unsupportedUnaryOp
 
 def mkBinOp {Γ : Ctxt (MTy φ)} {ty : (MTy φ)} (op : MOp φ)
     (e₁ e₂ : Ctxt.Var Γ ty) : MLIR.AST.ExceptM (MOp φ) <| Expr (MOp φ) Γ ty :=
   match ty with
   | .bitvec w =>
     match op with
-    -- Can't use a single arm, Lean won't write the rhs accordingly
-    | .add w' => if h : w = w'
+    | .binary w' op => if h : w = w'
       then return ⟨
-        .add w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-    | .and w' => if h : w = w'
-      then return ⟨
-        .and w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-    | .or w' => if h : w = w'
-      then return ⟨
-        .or w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-    | .xor w' => if h : w = w'
-      then return ⟨
-        .xor w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-    | .shl w' => if h : w = w'
-      then return ⟨
-        .shl w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-    | .lshr w' => if h : w = w'
-      then return ⟨
-        .lshr w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-    | .ashr w' => if h : w = w'
-      then return ⟨
-        .ashr w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-     | .urem w' => if h : w = w'
-      then return ⟨
-        .urem w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-     | .srem w' => if h : w = w'
-      then return ⟨
-        .srem w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-     | .mul w' => if h : w = w'
-      then return ⟨
-        .mul w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-      | .sub w' => if h : w = w'
-      then return ⟨
-        .sub w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-      | .sdiv w' => if h : w = w'
-      then return ⟨
-        .sdiv w',
-        by simp [OpSignature.outTy, signature, h],
-        .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
-        .nil
-      ⟩
-      else throw <| .widthError w w'
-      | .udiv w' => if  h : w = w'
-      then return ⟨
-        .udiv w',
+        .binary w' op,
         by simp [OpSignature.outTy, signature, h],
         .cons (h ▸ e₁) <| .cons (h ▸ e₂) .nil ,
         .nil
@@ -356,7 +242,7 @@ def MOp.instantiateCom (vals : Vector Nat φ) : DialectMorphism (MOp φ) (InstCo
     simp only [instantiateMTy, instantiateMOp, ConcreteOrMVar.instantiate, (· <$> ·), signature,
       InstCombine.MOp.sig, InstCombine.MOp.outTy, Function.comp_apply, List.map, Signature.mk.injEq,
       true_and]
-    cases op <;> simp only [List.map, and_self, List.cons.injEq]
+    cases op using MOp.deepCasesOn <;> simp only [List.map, and_self, List.cons.injEq]
 
 
 open InstCombine (Op Ty) in

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -171,23 +171,9 @@ def instantiateMTy (vals : Vector Nat φ) : (MTy φ) → InstCombine.Ty
   | .bitvec w => .bitvec <| .concrete <| w.instantiate vals
 
 def instantiateMOp (vals : Vector Nat φ) : MOp φ → InstCombine.Op
-  | .and w => .and (w.instantiate vals)
-  | .or w => .or (w.instantiate vals)
-  | .not w => .not (w.instantiate vals)
-  | .xor w => .xor (w.instantiate vals)
-  | .shl w => .shl (w.instantiate vals)
-  | .lshr w => .lshr (w.instantiate vals)
-  | .ashr w => .ashr (w.instantiate vals)
-  | .urem w => .urem (w.instantiate vals)
-  | .srem w => .srem (w.instantiate vals)
+  | .binary w binOp => .binary (w.instantiate vals) binOp
+  | .unary w unOp => .unary (w.instantiate vals) unOp
   | .select w => .select (w.instantiate vals)
-  | .add w => .add (w.instantiate vals)
-  | .mul w => .mul (w.instantiate vals)
-  | .sub w => .sub (w.instantiate vals)
-  | .neg w => .neg (w.instantiate vals)
-  | .copy w => .copy (w.instantiate vals)
-  | .sdiv w => .sdiv (w.instantiate vals)
-  | .udiv w => .udiv (w.instantiate vals)
   | .icmp c w => .icmp c (w.instantiate vals)
   | .const w val => .const (w.instantiate vals) val
 
@@ -201,8 +187,7 @@ def MOp.instantiateCom (vals : Vector Nat φ) : DialectMorphism (MOp φ) (InstCo
     simp only [instantiateMTy, instantiateMOp, ConcreteOrMVar.instantiate, (· <$> ·), signature,
       InstCombine.MOp.sig, InstCombine.MOp.outTy, Function.comp_apply, List.map, Signature.mk.injEq,
       true_and]
-    cases op using MOp.deepCasesOn <;> simp only [List.map, and_self, List.cons.injEq]
-
+    cases op <;> simp only [List.map, and_self, List.cons.injEq]
 
 open InstCombine (Op Ty) in
 def mkComInstantiate (reg : MLIR.AST.Region φ) :

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -74,25 +74,6 @@ def mkSelect {Γ : Ctxt (MTy φ)} {ty : (MTy φ)} (op : MOp φ)
         else throw <| .widthError w w'
         | _ => throw <| .unsupportedOp "Unsupported select operation"
 
-def mkOpExpr {Γ : Ctxt (MTy φ)} (op : MOp φ)
-    (arg : HVector (fun t => Ctxt.Var Γ t) (OpSignature.sig op)) :
-    MLIR.AST.ExceptM (MOp φ) <| Expr (MOp φ) Γ (OpSignature.outTy op) :=
-  match op with
-  | .and _ | .or _ | .xor _ | .shl _ | .lshr _ | .ashr _
-  | .add _ | .mul _ | .sub _ | .udiv _ | .sdiv _
-  | .srem _ | .urem _  =>
-    let (e₁, e₂) := arg.toTuple
-    mkBinOp op e₁ e₂
-  | .icmp _ _ =>
-    let (e₁, e₂) := arg.toTuple
-    mkIcmp op e₁ e₂
-  | .not _ | .neg _ | .copy _ =>
-    mkUnaryOp op arg.head
-  | .select _ =>
-    let (c, e₁, e₂) := arg.toTuple
-    mkSelect op c e₁ e₂
-  | .const .. => throw <| .unsupportedOp  "Tried to build (MOp φ) expression from constant"
-
 def mkTy : MLIR.AST.MLIRType φ → MLIR.AST.ExceptM (MOp φ) (MTy φ)
   | MLIR.AST.MLIRType.int MLIR.AST.Signedness.Signless w => do
     return .bitvec w


### PR DESCRIPTION
A refactor to clean up some of the EDSL code that got merged in #128.

By adding a bit more structure to the `MOp` type, we can greatly reduce the LOC we need in EDSL, by consolidating a bunch of carbon-copy match arms into just one.
Also, I've removed `mkOpExpr` since it did not seem to be used anywhere.