### PR TITLE
feat: recursion principles for contexts and valuations

### DIFF
--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -35,6 +35,8 @@ inductive MTy (φ : Nat)
 
 abbrev Ty := MTy 0
 
+@[match_pattern] abbrev Ty.bitvec (w : Nat) : Ty := MTy.bitvec (.concrete w)
+
 instance : Repr (MTy φ) where
   reprPrec
     | .bitvec (.concrete w), _ => "i" ++ repr w
@@ -47,7 +49,7 @@ instance : ToString (MTy φ) where
   toString t := repr t |>.pretty
 
 def Ty.width : Ty → Nat
-  | .bitvec (.concrete w) => w
+  | .bitvec w => w
 
 @[simp]
 theorem Ty.width_eq (ty : Ty) : .bitvec (ty.width) = ty := by
@@ -60,7 +62,7 @@ def BitVec.width {n : Nat} (_ : BitVec n) : Nat := n
 
 instance : Goedel Ty where
 toType := fun
-  | .bitvec (.concrete w) => Option $ BitVec w
+  | .bitvec w => Option $ BitVec w
 
 instance : Repr (BitVec n) where
   reprPrec

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -168,7 +168,7 @@ instance : AST.TransformReturn (MOp φ) (MTy φ) φ where
 -/
 
 def instantiateMTy (vals : Vector Nat φ) : (MTy φ) → InstCombine.Ty
-  | .bitvec w => .bitvec <| .concrete <| w.instantiate vals
+  | .bitvec w => .bitvec <| w.instantiate vals
 
 def instantiateMOp (vals : Vector Nat φ) : MOp φ → InstCombine.Op
   | .binary w binOp => .binary (w.instantiate vals) binOp


### PR DESCRIPTION
Attempt at fixing some of the alive examples that are currently not working.
Mostly dumping this here in case anyone wants to have a look next week.

The most usable parts so far are the extra recursion principles for `Ctxt` and `Ctxt.Valuation`: I hope to replace the current `generalize ...` trick with a bit of meta code that analyzes the type of a `Ctxt.Valuation`, recursively applies the case distinction until the remaining context is empty, and then reduces the `(Ctxt.Valuation.snoc _ v) (Var.last ..)` to just `v` --- we have a simp-lemma that should do this rewrite, but it somehow fails to unify with the lhs correctly, this might be a job for `simproc`.