### PR TITLE
feat: fix bitwidth to a single width across args and return value

### DIFF
--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -156,7 +156,7 @@ bits in op1, this instruction returns a poison value.
 def shl? {n} (op1 : BitVec n) (op2 : BitVec n) : Option (BitVec n) :=
   let bits := op2.toNat -- should this be toInt?
   if bits >= n then .none
-  else .some <| (op1 <<< op2)
+  else some (op1 <<< op2)
 
 /--
 This instruction always performs a logical shift right operation.

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -171,7 +171,7 @@ Corresponds to `Std.BitVec.ushiftRight` in the `some` case.
 def lshr? {n} (op1 : BitVec n) (op2 : BitVec n) : Option (BitVec n) :=
   let bits := op2.toNat -- should this be toInt?
   if bits >= n then .none
-  else .some <| (op1 >>> op2)
+  else some (op1 >>> op2)
 
 
 /--

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -186,7 +186,7 @@ Corresponds to `Std.BitVec.sshiftRight` in the `some` case.
 def ashr? {n} (op1 : BitVec n) (op2 : BitVec n) : Option (BitVec n) :=
   let bits := op2.toNat -- should this be toInt?
   if bits >= n then .none
-  else .some <| (op1 >>>ₛ op2)
+  else some (op1 >>>ₛ op2)
 
 /--
  If the condition is an i1 and it evaluates to 1, the instruction returns the first value argument; otherwise, it returns the second value argument.

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -153,10 +153,10 @@ The value produced is op1 * 2^op2 mod 2n, where n is the width of the result.
 If op2 is (statically or dynamically) equal to or larger than the number of
 bits in op1, this instruction returns a poison value.
 -/
-def shl? {m n k} (op1 : BitVec n) (op2 : BitVec m) : Option (BitVec k) :=
+def shl? {n} (op1 : BitVec n) (op2 : BitVec n) : Option (BitVec n) :=
   let bits := op2.toNat -- should this be toInt?
   if bits >= n then .none
-  else .some <| BitVec.coeWidth (op1 <<< op2)
+  else .some <| (op1 <<< op2)
 
 /--
 This instruction always performs a logical shift right operation.
@@ -168,10 +168,10 @@ this instruction returns a poison value.
 
 Corresponds to `Std.BitVec.ushiftRight` in the `some` case.
 -/
-def lshr? {m n k} (op1 : BitVec n) (op2 : BitVec m) : Option (BitVec k) :=
+def lshr? {n} (op1 : BitVec n) (op2 : BitVec n) : Option (BitVec n) :=
   let bits := op2.toNat -- should this be toInt?
   if bits >= n then .none
-  else .some <| BitVec.coeWidth (op1 >>> op2)
+  else .some <| (op1 >>> op2)
 
 
 /--
@@ -183,10 +183,10 @@ this instruction returns a poison value.
 
 Corresponds to `Std.BitVec.sshiftRight` in the `some` case.
 -/
-def ashr? {m n k} (op1 : BitVec n) (op2 : BitVec m) : Option (BitVec k) :=
+def ashr? {n} (op1 : BitVec n) (op2 : BitVec n) : Option (BitVec n) :=
   let bits := op2.toNat -- should this be toInt?
   if bits >= n then .none
-  else .some <| BitVec.coeWidth (op1 >>>ₛ op2)
+  else .some <| (op1 >>>ₛ op2)
 
 /--
  If the condition is an i1 and it evaluates to 1, the instruction returns the first value argument; otherwise, it returns the second value argument.


### PR DESCRIPTION
This makes the LLVM semantics agree precisely with our definitions. 