### PR TITLE
feat: hide monadic behavior of llvm semantics behind a function boundary.

### DIFF
--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -49,6 +49,24 @@ def get {as} : HVector A as → (i : Fin as.length) → A (as.get i)
   | .cons x  _, ⟨0,   _⟩  => x
   | .cons _ xs, ⟨i+1, h⟩  => get xs ⟨i, Nat.succ_lt_succ_iff.mp h⟩
 
+/-- To be used as an auto-tactic to prove that the index of getN is within bounds -/
+macro "hvector_get_elem_tactic" : tactic =>
+  `(tactic|
+      (
+      simp [List.length]
+      )
+   )
+
+/-- `x.getN i` indexes into a `HVector` with a `Nat`.
+
+Note that we cannot define a proper instance of `GetElem` for `HVector`,
+since `GetElem` requires us to specify a type `elem` such that `xs[i] : elem`,
+but `elem` is *not* allowed to depend on the concrete index `i`.
+Thus, `GetElem` does not properly support heterogeneous container types like `HVector`
+-/
+abbrev getN (x : HVector A as) (i : Nat) (hi : i < as.length := by hvector_get_elem_tactic) :
+    A (as.get ⟨i, hi⟩) :=
+  x.get ⟨i, hi⟩
 
 def ToTupleType (A : α → Type*) : List α → Type _
   | [] => PUnit

--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -63,7 +63,7 @@ macro "simp_peephole" "[" ts: Lean.Parser.Tactic.simpLemma,* "]" "at" ll:ident :
         Com.denote, Expr.denote, HVector.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
         Ctxt.empty, Ctxt.empty_eq, Ctxt.snoc, Ctxt.Valuation.nil, Ctxt.Valuation.snoc_last,
         Ctxt.Valuation.snoc_eval, Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
-        HVector.map, HVector.toSingle, HVector.toPair, HVector.toTuple,
+        HVector.map, HVector.getN, HVector.get, HVector.toSingle, HVector.toPair, HVector.toTuple,
         OpDenote.denote, Expr.op_mk, Expr.args_mk,
         DialectMorphism.mapOp, DialectMorphism.mapTy, List.map, Ctxt.snoc, List.map,
         Function.comp, Valuation.ofPair, Valuation.ofHVector, Function.uncurry,

--- a/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
@@ -50,14 +50,9 @@ BitVec.toNat (BitVec.ofInt w 0) = 0 := by
 theorem alive_DivRemOfSelect (w : Nat) :
     alive_DivRemOfSelect_src w ⊑ alive_DivRemOfSelect_tgt w := by
   unfold alive_DivRemOfSelect_src alive_DivRemOfSelect_tgt
-  intros Γv
-  simp_peephole at Γv
-  simp (config := {decide := false }) only [OpDenote.denote,
-    InstCombine.Op.denote,
-    HVector.toTuple, HVector.toPair, HVector.toTriple,
-    pairMapM, BitVec.Refinement,
-    simp_llvm,
-    ]
+  simp_alive_ssa
+  simp_alive_undef
+  simp [simp_llvm]
   intro y x c
   cases c
   -- | select condition is itself `none`, nothing more to be done. propagate the `none`.

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -247,30 +247,28 @@ instance : OpSignature (MOp φ) (MTy φ) where
   signature op := ⟨op.sig, [], op.outTy⟩
 
 @[simp]
-def Op.denote (o : Op) (arg : HVector TyDenote.toType (OpSignature.sig o)) :
+def Op.denote (o : Op) (op : HVector TyDenote.toType (OpSignature.sig o)) :
     (TyDenote.toType <| OpSignature.outTy o) :=
   match o with
   | Op.const _ val => const? val
-  | Op.and _ => pairBind and? arg.toPair
-  | Op.or _ => pairBind or? arg.toPair
-  | Op.xor _ => pairBind xor? arg.toPair
-  | Op.shl _ => pairBind shl? arg.toPair
-  | Op.lshr _ => pairBind lshr? arg.toPair
-  | Op.ashr _ => pairBind ashr? arg.toPair
-  | Op.sub _ => pairBind sub?  arg.toPair
-  | Op.add _ => pairBind add? arg.toPair
-  | Op.mul _ => pairBind mul? arg.toPair
-  | Op.sdiv _ => pairBind sdiv? arg.toPair
-  | Op.udiv _ => pairBind udiv? arg.toPair
-  | Op.urem _ => pairBind urem? arg.toPair
-  | Op.srem _ => pairBind srem? arg.toPair
-  | Op.not _ => Option.map (~~~.) arg.toSingle
-  | Op.copy _ => arg.toSingle
-  | Op.neg _ => Option.map (-.) arg.toSingle
-  | Op.select _ =>
-    let (ocond, otrue, ofalse) := arg.toTriple
-    select? ocond otrue ofalse
-  | Op.icmp c _ => pairBind (icmp? c) arg.toPair
+  | Op.copy _      =>             (op.getN 0)
+  | Op.not _       => LLVM.not    (op.getN 0)
+  | Op.neg _       => LLVM.neg    (op.getN 0)
+  | Op.and _       => LLVM.and    (op.getN 0) (op.getN 1)
+  | Op.or _        => LLVM.or     (op.getN 0) (op.getN 1)
+  | Op.xor _       => LLVM.xor    (op.getN 0) (op.getN 1)
+  | Op.shl _       => LLVM.shl    (op.getN 0) (op.getN 1)
+  | Op.lshr _      => LLVM.lshr   (op.getN 0) (op.getN 1)
+  | Op.ashr _      => LLVM.ashr   (op.getN 0) (op.getN 1)
+  | Op.sub _       => LLVM.sub    (op.getN 0) (op.getN 1)
+  | Op.add _       => LLVM.add    (op.getN 0) (op.getN 1)
+  | Op.mul _       => LLVM.mul    (op.getN 0) (op.getN 1)
+  | Op.sdiv _      => LLVM.sdiv   (op.getN 0) (op.getN 1)
+  | Op.udiv _      => LLVM.udiv   (op.getN 0) (op.getN 1)
+  | Op.urem _      => LLVM.urem   (op.getN 0) (op.getN 1)
+  | Op.srem _      => LLVM.srem   (op.getN 0) (op.getN 1)
+  | Op.icmp c _    => LLVM.icmp c (op.getN 0) (op.getN 1)
+  | Op.select _    => LLVM.select (op.getN 0) (op.getN 1) (op.getN 2)
 
 instance : OpDenote Op Ty := ⟨
   fun o args _ => Op.denote o args

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -8,20 +8,36 @@ import SSA.Projects.InstCombine.LLVM.SimpSet
 
 namespace LLVM
 
+
+abbrev IntW w := Option <| BitVec w
+
 /--
 The ‘and’ instruction returns the bitwise logical and of its two operands.
 -/
 @[simp_llvm]
-def and? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def and? {w : Nat} (x y : BitVec w) : IntW w :=
   some <| x &&& y
+
+@[simp_llvm_option]
+def and {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  and? x' y'
 
 /--
 The ‘or’ instruction returns the bitwise logical inclusive or of its two
 operands.
 -/
 @[simp_llvm]
-def or? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def or? {w : Nat} (x y : BitVec w) : IntW w :=
   some <| x ||| y
+
+
+@[simp_llvm_option]
+def or {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  or? x' y'
 
 /--
 The ‘xor’ instruction returns the bitwise logical exclusive or of its two
@@ -29,8 +45,14 @@ operands.  The xor is used to implement the “one’s complement” operation, 
 is the “~” operator in C.
 -/
 @[simp_llvm]
-def xor? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def xor? {w : Nat} (x y : BitVec w) : IntW w :=
   some <| x ^^^ y
+
+@[simp_llvm_option]
+def xor {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  xor? x' y'
 
 /--
 The value produced is the integer sum of the two operands.
@@ -38,8 +60,14 @@ If the sum has unsigned overflow, the result returned is the mathematical result
 Because LLVM integers use a two’s complement representation, this instruction is appropriate for both signed and unsigned integers.
 -/
 @[simp_llvm]
-def add? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def add? {w : Nat} (x y : BitVec w) : IntW w :=
   some <| x + y
+
+@[simp_llvm_option]
+def add {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  add? x' y'
 
 /--
 The value produced is the integer difference of the two operands.
@@ -47,8 +75,14 @@ If the difference has unsigned overflow, the result returned is the mathematical
 Because LLVM integers use a two’s complement representation, this instruction is appropriate for both signed and unsigned integers.
 -/
 @[simp_llvm]
-def sub? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def sub? {w : Nat} (x y : BitVec w) : IntW w :=
   some <| x - y
+
+@[simp_llvm_option]
+def sub {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  sub? x' y'
 
 /--
 The value produced is the integer product of the two operands.
@@ -62,8 +96,14 @@ If a full product (e.g. i32 * i32 -> i64) is needed, the operands should be
 sign-extended or zero-extended as appropriate to the width of the full product.
 -/
 @[simp_llvm]
-def mul? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def mul? {w : Nat} (x y : BitVec w) : IntW w :=
   some <| x * y
+
+@[simp_llvm_option]
+def mul {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  mul? x' y'
 
 /--
 The value produced is the unsigned integer quotient of the two operands.
@@ -71,10 +111,16 @@ Note that unsigned integer division and signed integer division are distinct ope
 Division by zero is undefined behavior.
 -/
 @[simp_llvm]
-def udiv? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def udiv? {w : Nat} (x y : BitVec w) : IntW w :=
   match y.toNat with
     | 0 => none
     | _ => some <| BitVec.ofInt w (x.toNat / y.toNat)
+
+@[simp_llvm_option]
+def udiv {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  udiv? x' y'
 
 def intMin (w : Nat) : BitVec w :=
   - BitVec.ofNat w (2^(w - 1))
@@ -101,10 +147,16 @@ at width 2, -4 / -1 is considered overflow!
 -- but we do not consider overflow when `w=1`, because `w=1` only has a sign bit, so there
 -- is no magniture to overflow.
 @[simp_llvm]
-def sdiv? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def sdiv? {w : Nat} (x y : BitVec w) : IntW w :=
   if y == 0 || (w != 1 && x == (intMin w) && y == -1)
   then .none
   else BitVec.sdiv x y
+
+@[simp_llvm_option]
+def sdiv {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  sdiv? x' y'
 
 -- Probably not a Mathlib worthy name, not sure how you'd mathlibify the precondition
 @[simp_llvm]
@@ -122,10 +174,16 @@ Note that unsigned integer remainder and signed integer remainder are distinct o
 Taking the remainder of a division by zero is undefined behavior.
 -/
 @[simp_llvm]
-def urem? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def urem? {w : Nat} (x y : BitVec w) : IntW w :=
   if y.toNat = 0
   then none
   else some <| BitVec.ofNat w (x.toNat % y.toNat)
+
+@[simp_llvm_option]
+def urem {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  urem? x' y'
 
 @[simp_llvm]
 def _root_.Int.rem (x y : Int) : Int :=
@@ -153,8 +211,14 @@ The fundamental equation of div/rem is: x = (x/y) * y + x%y
 We use this equation to define srem.
 -/
 @[simp_llvm]
-def srem? {w : Nat} (x y : BitVec w) : Option <| BitVec w :=
+def srem? {w : Nat} (x y : BitVec w) : IntW w :=
   (sdiv? x y).map (fun div => x - div * y)
+
+@[simp_llvm_option]
+def srem {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  srem? x' y'
 
 @[simp_llvm]
 def sshr (a : BitVec n) (s : Nat) := BitVec.sshiftRight a s
@@ -166,10 +230,17 @@ If op2 is (statically or dynamically) equal to or larger than the number of
 bits in op1, this instruction returns a poison value.
 -/
 @[simp_llvm]
-def shl? {n} (op1 : BitVec n) (op2 : BitVec n) : Option (BitVec n) :=
+def shl? {n} (op1 : BitVec n) (op2 : BitVec n) : IntW n :=
   let bits := op2.toNat -- should this be toInt?
   if bits >= n then .none
   else some (op1 <<< op2)
+
+
+@[simp_llvm_option]
+def shl {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  shl? x' y'
 
 /--
 This instruction always performs a logical shift right operation.
@@ -182,11 +253,16 @@ this instruction returns a poison value.
 Corresponds to `Std.BitVec.ushiftRight` in the `some` case.
 -/
 @[simp_llvm]
-def lshr? {n} (op1 : BitVec n) (op2 : BitVec n) : Option (BitVec n) :=
+def lshr? {n} (op1 : BitVec n) (op2 : BitVec n) : IntW n :=
   let bits := op2.toNat -- should this be toInt?
   if bits >= n then .none
   else some (op1 >>> op2)
 
+@[simp_llvm_option]
+def lshr {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  lshr? x' y'
 
 /--
 This instruction always performs an arithmetic shift right operation,
@@ -198,18 +274,24 @@ this instruction returns a poison value.
 Corresponds to `Std.BitVec.sshiftRight` in the `some` case.
 -/
 @[simp_llvm]
-def ashr? {n} (op1 : BitVec n) (op2 : BitVec n) : Option (BitVec n) :=
+def ashr? {n} (op1 : BitVec n) (op2 : BitVec n) : IntW n :=
   let bits := op2.toNat -- should this be toInt?
   if bits >= n then .none
   else some (op1 >>>ₛ op2)
+
+@[simp_llvm_option]
+def ashr {w : Nat} (x y : IntW w) : IntW w := do
+  let x' ← x
+  let y' ← y
+  ashr? x' y'
 
 /--
  If the condition is an i1 and it evaluates to 1, the instruction returns the first value argument; otherwise, it returns the second value argument.
 
  If the condition is an i1 and it evaluates to 1, the instruction returns the first value argument; otherwise, it returns the second value argument.
 -/
-@[simp_llvm]
-def select? {w : Nat} (c? : Option (BitVec 1)) (x? y? : Option (BitVec w)) : Option (BitVec w) :=
+@[simp_llvm_option]
+def select {w : Nat} (c? : IntW 1) (x? y? : IntW w ) : IntW w :=
   match c? with
   | none => none
   | some true => x?
@@ -261,7 +343,7 @@ The possible condition codes are:
 The remaining two arguments must be integer. They must also be identical types.
 -/
 @[simp_llvm]
-def icmp {w : Nat} (c : IntPredicate) (x y : BitVec w) : Bool :=
+def icmp' {w : Nat} (c : IntPredicate) (x y : BitVec w) : Bool :=
   match c with
     | .eq => (x == y)
     | .ne => (x != y)
@@ -296,8 +378,14 @@ The possible condition codes are:
 The remaining two arguments must be integer. They must also be identical types.
 -/
 @[simp_llvm]
-def icmp? {w : Nat} (c : IntPredicate) (x y : BitVec w) : Option (BitVec 1) :=
-  some ↑(icmp c x y)
+def icmp? {w : Nat} (c : IntPredicate) (x y : BitVec w) : IntW 1 :=
+  some ↑(icmp' c x y)
+
+@[simp_llvm_option]
+def icmp {w : Nat} (c : IntPredicate) (x y : IntW w) : IntW 1 := do
+  let x' ← x
+  let y' ← y
+  icmp? c x' y'
 
 /--
 Unlike LLVM IR, MLIR does not have first-class constant values.
@@ -317,7 +405,25 @@ the value `(2^w + (i mod 2^w)) mod 2^w`.
 TODO: double-check that truncating works the same as MLIR (signedness, overflow, etc)
 -/
 @[simp_llvm]
-def const? (i : Int): Option (BitVec w) :=
+def const? (i : Int): IntW w :=
   some <| BitVec.ofInt w i
+
+@[simp_llvm]
+def not? {w : Nat} (x : BitVec w) : IntW w := do
+  some (~~~x)
+
+@[simp_llvm_option]
+def not {w : Nat} (x : IntW w) : IntW w := do
+  let x' ← x
+  not? x'
+
+@[simp_llvm]
+def neg? {w : Nat} (x : BitVec w) : IntW w := do
+  some <| (-.) x
+
+@[simp_llvm_option]
+def neg {w : Nat} (x : IntW w) : IntW w := do
+  let x' ← x
+  neg? x'
 
 end LLVM

--- a/SSA/Projects/InstCombine/LLVM/SimpSet.lean
+++ b/SSA/Projects/InstCombine/LLVM/SimpSet.lean
@@ -3,3 +3,4 @@ import Lean.Meta.Tactic.Simp.RegisterCommand
 import Lean.LabelAttribute
 
 register_simp_attr simp_llvm
+register_simp_attr simp_llvm_option


### PR DESCRIPTION
We introduce with `LLVM.<op>` a set of formal definitions of the per-operation semantics for the LLVM dialect that must be unfolded with `simp_llvm_option` before the per-operation semantics are exposed. This allows us to introduce a tactic `simp_alive_ssa`, which eliminates only the overhead of SSA and leaves us with explicit statements about the not-yet-unfolded LLVM operation semantics.