### PR TITLE
chore: remove unused simp options

### DIFF
--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -57,7 +57,7 @@ macro "simp_peephole" "[" ts: Lean.Parser.Tactic.simpLemma,* "]" "at" ll:ident :
   `(tactic|
       (
       change_mlir_context $ll
-      simp (config := {failIfUnchanged := false, decide := false, unfoldPartialApp := true, zetaDelta := true}) only [
+      simp (config := {failIfUnchanged := false, decide := false }) only [
         Int.ofNat_eq_coe, Nat.cast_zero, DerivedCtxt.snoc, DerivedCtxt.ofCtxt,
         DerivedCtxt.ofCtxt_empty, Valuation.snoc_last,
         Com.denote, Expr.denote, HVector.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,

--- a/SSA/Projects/InstCombine/Tactic.lean
+++ b/SSA/Projects/InstCombine/Tactic.lean
@@ -27,7 +27,7 @@ macro "simp_alive_peephole" : tactic =>
         dsimp only [Com.Refinement]
         intros Γv
         simp_peephole [InstCombine.Op.denote] at Γv
-        simp (config := {failIfUnchanged := false, unfoldPartialApp := true, zetaDelta := true}) only [
+        simp (config := {failIfUnchanged := false}) only [
             BitVec.Refinement, bind, Option.bind, pure,
             simp_llvm,
             BitVec.bitvec_minus_one


### PR DESCRIPTION
If we do not need special simp options, we should probably stick to the default options as much as possible or document why we use different options. These two options look as if they potentially increase the computational cost of simp. As our current tests pass without them, we remove them for now. We can always add them back if we find a test case that would require them. We keep `decide := false` for now, as this seems to be a performance optimization.