### PR TITLE
chore: document `simp_alive_peephole`

### DIFF
--- a/SSA/Projects/InstCombine/Tactic.lean
+++ b/SSA/Projects/InstCombine/Tactic.lean
@@ -12,26 +12,46 @@ open MLIR AST
 open Std (BitVec)
 open Ctxt
 
+-- TODO: Do we call this dialect the "Alive" dialect (as hinted by the `simp_alive_peephole` name),
+--       or the "InstCombine" dialect (as hinted by the `InstCombine` namespace that everything
+--       lives in), or the "LLVM" dialect (as we do in the paper, and the simp-sets,
+--       and the `LLVM` namespace)?
+
 open MLIR AST in
 /--
-- We first simplify `Com.refinement` to see the context `Γv`.
-- We `simp_peephole Γv` to simplify context accesses by variables.
-- We simplify the translation overhead.
-- Then we introduce variables, `cases` on the variables to eliminate the `none` cases.
-- We cannot leave it at this state, since then the variables will be inaccessible.
-- So, we revert the variables for the user to re-introduce them as they see fit.
--/
+`simp_alive_peephole` extends `simp_peephole` to simplify goals about refinement of `InstCombine`
+programs into statements about just bitvectors.
+
+To wit, the tactic expects a goal of the form: `Com.Refinement com₁ com₂`
+That is, goals of of the form `Com.refine, com₁.denote Γv ⊑ com₂.denote Γv `,
+where `com₁` and `com₂` are programs in the `InstCombine`/`Alive`/`LLVM` dialect. -/
 macro "simp_alive_peephole" : tactic =>
   `(tactic|
       (
+        /- Unfold the meaning of refinement, to access the valuation -/
         dsimp only [Com.Refinement]
         intros Γv
+
+        /- Simplify away the core framework -/
         simp_peephole [InstCombine.Op.denote] at Γv
+
+        /- Simplify away the `InstCombine` specific semantics. -/
         simp (config := {failIfUnchanged := false}) only [
             BitVec.Refinement, bind, Option.bind, pure,
             simp_llvm,
             BitVec.bitvec_minus_one
           ]
+
+        /-  At this point, we have should a goal of the form:
+              `∀ (x₁ : Option (BitVec _)) ... (xₙ : Option (BitVec _)), ...`
+            For some unknown number of variables `n` (but assumed to be `n ≤ 5`,
+            as per the hack in `simp_peephole`).
+
+            However, the `none` (i.e., poison) cases are generally trivial.
+            Thus we attempt to introduce some variables (using `try` because the intro might fail
+            if we have less universal quantifiers than `intro`s), case split on them, and simp
+            through the monadic bind on `Option` (in the generally true assumption that the `none`
+            case becomes trivial and is closed by `simp`). -/
         try intros v0
         try intros v1
         try intros v2
@@ -46,6 +66,17 @@ macro "simp_alive_peephole" : tactic =>
           <;> try cases' v4 with x4 <;> simp[Option.bind, bind, Monad.toBind]
           <;> try cases' v5 with x5 <;> simp[Option.bind, bind, Monad.toBind]
           <;> dsimp[Option.bind, bind, Monad.toBind]
+
+        /-
+        CAVEAT: The following `revert`s currently have no effect,
+        the variables `v$i` have been cases on,
+        and the newly introduced variables (in the `some` cases) are called `x$i` instead,
+        I've documented the intended behaviour below.
+        TODO: fix or remove this
+
+        Finally, revert the variables introduced in the `some` cases, so that we are left with a
+        universally quantified goal of the form:
+          `∀ (x₁ : BitVec _) ... (xₙ : BitVec _), ...` -/
         try revert v5
         try revert v4
         try revert v3


### PR DESCRIPTION
The docstrings were taken from the side-effects branch, in an effort to reduce the diff