### PR TITLE
feat: Implement [fhe_com |...] to write FHE examples with sugar.

### DIFF
--- a/SSA/Projects/FullyHomomorphicEncryption.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption.lean
@@ -1,2 +1,4 @@
 import SSA.Projects.FullyHomomorphicEncryption.Basic
+import SSA.Projects.FullyHomomorphicEncryption.Rewrites
 import SSA.Projects.FullyHomomorphicEncryption.Statements
+import SSA.Projects.FullyHomomorphicEncryption.Syntax

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -640,7 +640,7 @@ inductive Ty (q : Nat) (n : Nat) [Fact (q > 1)]
   | integer : Ty q n
   | tensor : Ty q n
   | polynomialLike : Ty q n
-  deriving DecidableEq
+  deriving DecidableEq, Repr
 
 instance : Inhabited (Ty q n) := ⟨Ty.index⟩
 instance : TyDenote (Ty q n) where

--- a/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
@@ -1,43 +1,74 @@
+/-
+End-to-end showcase of the framework for verifying rewrites about FHE semantics.
+
+Authors: Andrés Goens<andres@goens.org>
+-/
+import SSA.Projects.MLIRSyntax.EDSL
+import SSA.Core.Tactic
 import SSA.Projects.FullyHomomorphicEncryption.Basic
 import SSA.Projects.FullyHomomorphicEncryption.Statements
-import SSA.Projects.MLIRSyntax.EDSL
+import SSA.Projects.FullyHomomorphicEncryption.Syntax
 
-theorem dialect_mul_comm :
-[mlir_icom| {
-^bb0(%A : P, %B : P):
-  %v1 = "poly.mul" (%A,%B) : (P, P) -> (P)
-  "poly.return" (%v1) : (P) -> ()
-}] = 
-[mlir_icom| {
-^bb0(%A : P, %B : P):
-  %v1 = "poly.mul" (%A,%B) : (P, P) -> (P)
-  "poly.return" (%v1) : (P) -> ()
-}]=  := by
-  simp_mlir
-  apply poly_mul_comm
+open Ctxt (Var Valuation DerivedCtxt)
 
-theorem dialect_add_comm : a + b = b + a := by
-  ring
+open MLIR AST -- need this to support the unhygenic macros in the EDSL
 
+/- Lemmas about the elements of the quotient ring. -/
+namespace RingLemmas
+
+/-- In the quotient ring, (f q n) = 0. -/
 theorem dialect_f_eq_zero : (f q n) = (0 : R q n) := by
   apply Ideal.Quotient.eq_zero_iff_mem.2
   rw [Ideal.mem_span_singleton]
 
-theorem dialect_mul_f_eq_zero : a * (f q n) = 0 := by
+/-- Since (f q n) = 0, anything multiplied by it is also zero. -/
+theorem dialect_mul_f_eq_zero (a : R q n) : a * (f q n) = 0 := by
   rw [dialect_f_eq_zero]; ring
 
-theorem dialect_mul_one_eq : 1 * a = a := by
-  ring
+/-- Since (f q n) = 0, adding it to any element gives the element itself. -/
+theorem dialect_add_f_eq (a : R q n) : a + (f q n) = a := by
+  rw [← one_mul a, dialect_f_eq_zero]; ring
 
-theorem dialect_add_f_eq : a + (f q n) = a := by
-  rw [← dialect_mul_one_eq q n (f q n), dialect_mul_f_eq_zero _ _ 1]; ring
-
-theorem dialect_add_zero_eq : a + 0 = a := by
-  ring
+end RingLemmas
 
 
+namespace ExampleComm
 
+variable {q : Nat} {n : Nat} [hq : Fact (q > 1)]
 
+def lhs :=
+[fhe_com q, n, hq| {
+^bb0(%A : ! R, %B : ! R):
+  %v1 = "poly.add" (%A,%B) : (! R, ! R) -> (! R)
+  "return" (%v1) : (! R) -> ()
+}]
 
+def rhs :=
+[fhe_com q, n, hq| {
+^bb0(%A : ! R, %B : ! R):
+  %v1 = "poly.add" (%B,%A) : (! R, ! R) -> (! R)
+  "return" (%v1) : (! R) -> ()
+}]
 
+open MLIR AST in
+noncomputable def p1 : PeepholeRewrite (Op q n) [.polynomialLike, .polynomialLike] .polynomialLike :=
+  { lhs := lhs, rhs := rhs, correct :=
+    by
+      rw [lhs, rhs]
+      /-:
+      Com.denote
+        (Com.lete (cst 0)
+        (Com.lete (add { val := 1, property := _ } { val := 0, property := _ })
+        (Com.ret { val := 0, property := ex1.proof_3 }))) =
+      Com.denote (Com.ret { val := 0, property := _ })
+      -/
+      funext Γv
+      simp_peephole [] at Γv
+      /- ⊢ ∀ (a b : R 2 3), b + a = a + b -/
+      intros a b
+      rw [add_comm]
+      /- No goals-/
+      done
+    }
 
+end ExampleComm

--- a/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
@@ -91,15 +91,6 @@ def mlir2fhe (reg : MLIR.AST.Region 0) :
 end MkFuns -- we don't want q and i here anymore
 
 open Qq MLIR AST Lean Elab Term Meta in
-/--
-NOTE: Wanting Stuck Terms During Strong Normalization of Com
-
-See that we unfold with `TransparencyMode.all`. We do this so we can expose Com.denote
-fully. This is a crazy hack, and interacts extremely poorly with complex definitions found in FHE.
-
-One neater solution is a `match goal` like tactic to match on the proof state
-and run the correct equation.
--/
 elab "[fhe_com" qi:term "," ni:term "," hq:term " | " reg:mlir_region "]" : term => do
   let ast_stx ← `([mlir_region| $reg])
   let ast ← elabTermEnsuringTypeQ ast_stx q(Region 0)

--- a/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
@@ -1,0 +1,127 @@
+/-
+Syntax definitions for FHE, providing a custom [fhe_com|...] with syntax sugar.
+
+Authors: Andrés Goens<andres@goens.org>
+-/
+import SSA.Projects.InstCombine.LLVM.Transform
+import SSA.Projects.MLIRSyntax.AST
+import SSA.Projects.MLIRSyntax.EDSL
+import SSA.Projects.FullyHomomorphicEncryption.Basic
+
+open MLIR AST Ctxt
+open Polynomial -- for R[X] notation
+
+section MkFuns
+variable {q : Nat} {n : Nat} [Fact (q > 1)]
+
+def mkTy : MLIR.AST.MLIRType φ → MLIR.AST.ExceptM (Op q n) (Ty q n)
+  | MLIR.AST.MLIRType.undefined "R" => do
+    return .polynomialLike
+  | MLIR.AST.MLIRType.int MLIR.AST.Signedness.Signless _ => do
+    return .integer
+  | MLIR.AST.MLIRType.index  => do
+    return .index
+  | _ => throw .unsupportedType
+
+instance instTransformTy : MLIR.AST.TransformTy (Op q n) (Ty q n) 0 where
+  mkTy := mkTy
+
+def add {Γ : Ctxt (Ty q n)} (e₁ e₂ : Var Γ .polynomialLike) : Expr (Op q n) Γ .polynomialLike :=
+  Expr.mk
+    (op := .add)
+    (ty_eq := rfl)
+    (args := .cons e₁ <| .cons e₂ .nil)
+    (regArgs := .nil)
+
+def mul {Γ : Ctxt (Ty q n)} (e₁ e₂ : Var Γ .polynomialLike) : Expr (Op q n) Γ .polynomialLike :=
+  Expr.mk
+    (op := .mul)
+    (ty_eq := rfl)
+    (args := .cons e₁ <| .cons e₂ .nil)
+    (regArgs := .nil)
+
+def mon {Γ : Ctxt (Ty q n)} (a : Var Γ .integer) (i : Var Γ .index) : Expr (Op q n) Γ .polynomialLike :=
+  Expr.mk
+    (op := .monomial)
+    (ty_eq := rfl)
+    (args := .cons a <| .cons i .nil)
+    (regArgs := .nil)
+
+def mkExpr (Γ : Ctxt (Ty q n)) (opStx : MLIR.AST.Op 0) :
+    MLIR.AST.ReaderM (Op q n) (Σ ty, Expr (Op q n) Γ ty) := do
+  match opStx.name with
+  | "poly.monomial" =>
+    match opStx.args with
+    | v₁Stx::v₂Stx::[] =>
+      let ⟨ty₁, v₁⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ v₁Stx
+      let ⟨ty₂, v₂⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ v₂Stx
+      match ty₁, ty₂ with
+        | .integer, .index => return ⟨.polynomialLike, mon v₁ v₂⟩
+        | _, _ => throw <| .generic s!"expected operands to be of types `integer` and `index` for `monomial`. Got: {repr ty₁}, {repr ty₂}"
+    | _ => throw <| .generic s!"expected two operands for `monomial`, found #'{opStx.args.length}' in '{repr opStx.args}'"
+  | "poly.add" =>
+    match opStx.args with
+    | v₁Stx::v₂Stx::[] =>
+      let ⟨ty₁, v₁⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ v₁Stx
+      let ⟨ty₂, v₂⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ v₂Stx
+      match ty₁, ty₂ with
+        | .polynomialLike, .polynomialLike => return ⟨.polynomialLike, add v₁ v₂⟩
+        | _, _ => throw <| .generic s!"expected both operands to be of type 'polynomialLike'"
+    | _ => throw <| .generic s!"expected two operands for `add`, found #'{opStx.args.length}' in '{repr opStx.args}'"
+  | _ => throw <| .unsupportedOp s!"unsupported operation {repr opStx}"
+
+instance : MLIR.AST.TransformExpr (Op q n) (Ty q n) 0 where
+  mkExpr := mkExpr
+
+def mkReturn (Γ : Ctxt (Ty q n)) (opStx : MLIR.AST.Op 0) : MLIR.AST.ReaderM (Op q n) (Σ ty, Com (Op q n) Γ ty) :=
+  if opStx.name == "return"
+  then match opStx.args with
+  | vStx::[] => do
+    let ⟨ty, v⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ vStx
+    return ⟨ty, Com.ret v⟩
+  | _ => throw <| .generic s!"Ill-formed return statement (wrong arity, expected 1, got {opStx.args.length})"
+  else throw <| .generic s!"Tried to build return out of non-return statement {opStx.name}"
+
+instance : MLIR.AST.TransformReturn (Op q n) (Ty q n) 0 where
+  mkReturn := mkReturn
+
+def mlir2fhe (reg : MLIR.AST.Region 0) :
+    MLIR.AST.ExceptM (Op q n) (Σ (Γ : Ctxt (Ty q n)) (ty : (Ty q n)), Com (Op q n) Γ ty) := MLIR.AST.mkCom reg
+
+end MkFuns -- we don't want q and i here anymore
+
+open Qq MLIR AST Lean Elab Term Meta in
+/--
+NOTE: Wanting Stuck Terms During Strong Normalization of Com
+
+See that we unfold with `TransparencyMode.all`. We do this so we can expose Com.denote
+fully. This is a crazy hack, and interacts extremely poorly with complex definitions found in FHE.
+
+One neater solution is a `match goal` like tactic to match on the proof state
+and run the correct equation.
+-/
+elab "[fhe_com" qi:term "," ni:term "," hq:term " | " reg:mlir_region "]" : term => do
+  let ast_stx ← `([mlir_region| $reg])
+  let ast ← elabTermEnsuringTypeQ ast_stx q(Region 0)
+  let qval : Q(Nat) ← elabTermEnsuringTypeQ qi q(Nat)
+  let nval : Q(Nat) ← elabTermEnsuringTypeQ ni q(Nat)
+  -- We need this for building `R  later
+  -- I would like to synthesize this at elaboration time, not sure how
+  let _factval ← elabTermEnsuringTypeQ hq q(Fact ($qval > 1))
+  let com := q(mlir2fhe (q := $qval) (n := $nval) $ast)
+  synthesizeSyntheticMVarsNoPostponing
+  let com : Q(MLIR.AST.ExceptM (Op 2 3) (Σ (Γ' : Ctxt (Ty 2 3)) (ty : Ty 2 3), Com (Op 2 3) Γ' ty)) ←
+    withTheReader Core.Context (fun ctx => { ctx with options := ctx.options.setBool `smartUnfolding false }) do
+      withTransparency (mode := TransparencyMode.default) <|
+        return ←reduce com
+  let comExpr : Expr := com
+  match comExpr.app3? ``Except.ok with
+  | .some (_εexpr, _αexpr, aexpr) =>
+      match aexpr.app4? ``Sigma.mk with
+      | .some (_αexpr, _βexpr, _fstexpr, sndexpr) =>
+        match sndexpr.app4? ``Sigma.mk with
+        | .some (_αexpr, _βexpr, _fstexpr, sndexpr) =>
+            return sndexpr
+        | .none => throwError "Found `Except.ok (Sigma.mk _ WRONG)`, Expected (Except.ok (Sigma.mk _ (Sigma.mk _ _))"
+      | .none => throwError "Found `Except.ok WRONG`, Expected (Except.ok (Sigma.mk _ _))"
+  | .none => throwError "Expected `Except.ok`, found {comExpr}"


### PR DESCRIPTION
This adds a new `[fhe_com |...]`, mimicking the `[alive_com|...]`, that provides a prettier syntax to write FHE examples in.

---
Code peeled from pre-paper submission PR: https://github.com/opencompl/ssa/pull/196.
Code stacked on: https://github.com/opencompl/ssa/pull/230.