### PR TITLE
feat: add const_int and const_idx operations to FHE

### DIFF
--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -667,6 +667,9 @@ inductive Op (q : Nat) (n : Nat) [Fact (q > 1)]
   | from_tensor : Op q n-- interpret values as coefficients of a representative
   | to_tensor : Op q n-- give back coefficients from `R.representative`
   | const (c : R q n) : Op q n
+  | const_int (c : Int) : Op q n
+  | const_idx (i : Nat) : Op q n
+
 
 open TyDenote (toType)
 
@@ -683,12 +686,17 @@ def Op.sig : Op  q n → List (Ty q n)
 | Op.from_tensor => [Ty.tensor]
 | Op.to_tensor => [Ty.polynomialLike]
 | Op.const _ => []
+| Op.const_int _ => []
+| Op.const_idx _ => []
+
 
 @[simp, reducible]
 def Op.outTy : Op q n → Ty q n
 | Op.add | Op.sub | Op.mul | Op.mul_constant | Op.leading_term | Op.monomial
 | Op.monomial_mul | Op.from_tensor | Op.const _  => Ty.polynomialLike
 | Op.to_tensor => Ty.tensor
+| Op.const_int _ => Ty.integer
+| Op.const_idx _ => Ty.index
 
 @[simp, reducible]
 def Op.signature : Op q n → Signature (Ty q n) :=
@@ -709,3 +717,6 @@ noncomputable instance : OpDenote (Op q n) (Ty q n) where
     | Op.from_tensor, arg, _ => R.fromTensor arg.toSingle
     | Op.to_tensor, arg, _ => R.toTensor' arg.toSingle
     | Op.const c, _arg, _ => c
+    | Op.const_int c, _, _ => c
+    | Op.const_idx c, _, _ => c
+

--- a/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
@@ -26,6 +26,20 @@ def mkTy : MLIR.AST.MLIRType φ → MLIR.AST.ExceptM (Op q n) (Ty q n)
 instance instTransformTy : MLIR.AST.TransformTy (Op q n) (Ty q n) 0 where
   mkTy := mkTy
 
+def cstInt {Γ : Ctxt _} (z :Int) : Expr (Op q n) Γ .integer  :=
+  Expr.mk
+    (op := .const_int z)
+    (ty_eq := rfl)
+    (args := .nil)
+    (regArgs := .nil)
+
+def cstIdx {Γ : Ctxt _} (i : Nat) : Expr (Op q n) Γ .index :=
+  Expr.mk
+    (op := .const_idx i)
+    (ty_eq := rfl)
+    (args := .nil)
+    (regArgs := .nil)
+
 def add {Γ : Ctxt (Ty q n)} (e₁ e₂ : Var Γ .polynomialLike) : Expr (Op q n) Γ .polynomialLike :=
   Expr.mk
     (op := .add)


### PR DESCRIPTION
Co-authored-by: Andrés Goens <andres@goens.org>

Code peeled from pre-paper submission PR: https://github.com/opencompl/ssa/pull/196.
Code stacked on: https://github.com/opencompl/ssa/pull/231.

We add two operations, `const_int` and `const_idx` which are used in the big example from the paper: 

```lean
noncomputable def lhs :=
[fhe_com q, n, hq| {
^bb0(%a : ! R):
  %one_int = "arith.const" () {value = 1}: () -> (i16)
  %two_to_the_n = "arith.const" () {value = $((2**n : Int))}: () -> (index)
  %x2n = "poly.monomial" (%one_int,%two_to_the_n) : (i16, index) -> (! R)
  %oner = "poly.const" () {value = 1}: () -> (! R)
  %p = "poly.add" (%x2n, %oner) : (! R, ! R) -> (! R)
  %v1 = "poly.add" (%a, %p) : (! R, ! R) -> (! R)
  "return" (%v1) : (! R) -> ()
}]
```