### PR TITLE
feat: add example from paper for FHE.

### DIFF
--- a/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
@@ -82,7 +82,8 @@ infixl:50 "**" => irreduciblePow
 
 variable {q : Nat} {n : Nat} [hq : Fact (q > 1)]
 
--- code generator does not support recursor 'Decidable.rec' yet, consider using 'match ... with' and/or structural recursion
+-- We mark this as noncomputable due to the presence of poly.const, which creates a value of type R.
+-- This operation is noncomputable, as we use `coe` from `Int` to `R`, which is a noncomputable instance. 
 noncomputable def lhs := [fhe_com q, n, hq| {
 ^bb0(%a : ! R):
   %one_int = "arith.const" () {value = 1}: () -> (i16)

--- a/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
@@ -145,6 +145,6 @@ noncomputable def p1 : PeepholeRewrite (Op q n) [.polynomialLike] .polynomialLik
       apply Poly.add_f_eq
       done
     }
-/- 'p1' depends on axioms: [propext, Classical.choice, Quot.sound, ROfZComputable_stuck_term, ROfZComputable_def] -/
-#print axioms p1
+/--info: 'p1' depends on axioms: [propext, Classical.choice, Quot.sound, ROfZComputable_stuck_term, ROfZComputable_def] -/
+#guard_msgs in #print axioms p1
 end ExampleModulo

--- a/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
@@ -138,11 +138,7 @@ noncomputable def p1 : PeepholeRewrite (Op q n) [.polynomialLike] .polynomialLik
       /- ⊢ a + ((Ideal.Quotient.mk (Ideal.span {f q n})) ((Polynomial.monomial (2**n)) 1) + 1) = a -/
       intros a
       unfold irreduciblePow
-      --have hgenerator : f 2 3 = (Polynomial.monomial 8 1) + 1  := by simp [f, Polynomial.X_pow_eq_monomial]
       have hgenerator : f q n - (1 : Polynomial (ZMod q)) = (Polynomial.monomial (R := ZMod q) (2^n : Nat) 1)  := by simp  [f, Polynomial.X_pow_eq_monomial]
-      --set_option pp.all true in
-      -- `rw` bug? or because of the workaround?
-      -- tactic 'rewrite' failed, motive is not type correct
       rw [← hgenerator]
       have add_congr_quotient : ((Ideal.Quotient.mk (Ideal.span {f q n})) (f q n - 1) + 1)  = ((Ideal.Quotient.mk (Ideal.span {f q n})) (f q n )) := by simp
       rw [add_congr_quotient]

--- a/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
@@ -72,3 +72,83 @@ noncomputable def p1 : PeepholeRewrite (Op q n) [.polynomialLike, .polynomialLik
     }
 
 end ExampleComm
+
+section ExampleModulo
+
+@[irreducible]
+def irreduciblePow (q n : Nat) : Nat := q^n
+infixl:50 "**" => irreduciblePow
+
+
+variable {q : Nat} {n : Nat} [hq : Fact (q > 1)]
+
+-- code generator does not support recursor 'Decidable.rec' yet, consider using 'match ... with' and/or structural recursion
+noncomputable def lhs := [fhe_com q, n, hq| {
+^bb0(%a : ! R):
+  %one_int = "arith.const" () {value = 1}: () -> (i16)
+  %two_to_the_n = "arith.const" () {value = $((2**n : Int))}: () -> (index)
+  %x2n = "poly.monomial" (%one_int,%two_to_the_n) : (i16, index) -> (! R)
+  %oner = "poly.const" () {value = 1}: () -> (! R)
+  %p = "poly.add" (%x2n, %oner) : (! R, ! R) -> (! R)
+  %v1 = "poly.add" (%a, %p) : (! R, ! R) -> (! R)
+  "return" (%v1) : (! R) -> ()
+}]
+
+def rhs := [fhe_com q, n, hq | {
+^bb0(%a : ! R):
+  "return" (%a) : (! R) -> ()
+}]
+
+/- 'lhs' depends on axioms: [propext, Quot.sound, Classical.choice, ROfZComputable_stuck_term] -/
+#print axioms lhs
+
+/-  `x^(2^n) + a = a`, since we quotient the polynomial ring with x^(2^n) -/
+open MLIR AST in
+noncomputable def p1 : PeepholeRewrite (Op q n) [.polynomialLike] .polynomialLike :=
+  { lhs := lhs,
+     rhs := rhs
+  , correct :=
+    by
+      funext Γv
+      unfold lhs rhs
+       /-
+      Com.denote
+          (Com.lete (Expr.mk (Op.const_int (Int.ofNat 1)) lhs.proof_2 HVector.nil HVector.nil)
+            (Com.lete (Expr.mk (Op.const_idx 1) lhs.proof_3 HVector.nil HVector.nil)
+              (Com.lete
+                (Expr.mk Op.monomial lhs.proof_4
+                  ({ val := 1, property := lhs.proof_5 }::ₕ({ val := 0, property := lhs.proof_6 }::ₕHVector.nil)) HVector.nil)
+                (Com.lete
+                  (Expr.mk (Op.const (ROfZComputable_stuck_term 2 3 (Int.ofNat 1))) lhs.proof_7 HVector.nil HVector.nil)
+                  (Com.lete
+                    (Expr.mk Op.add lhs.proof_8
+                      ({ val := 1, property := lhs.proof_9 }::ₕ({ val := 0, property := lhs.proof_10 }::ₕHVector.nil))
+                      HVector.nil)
+                    (Com.lete
+                      (Expr.mk Op.add lhs.proof_8
+                        ({ val := 5, property := lhs.proof_11 }::ₕ({ val := 0, property := lhs.proof_12 }::ₕHVector.nil))
+                        HVector.nil)
+                      (Com.ret { val := 0, property := lhs.proof_13 })))))))
+          Γv =
+        Com.denote (Com.ret { val := 0, property := rhs.proof_2 }) Γv
+       -/
+      simp_peephole [Nat.cast_one, Int.cast_one, ROfZComputable_def] at Γv
+      /- ⊢ ∀ (a : ⟦Ty.polynomialLike⟧), a + (R.monomial q n 1 (2**n) + 1) = a -/
+      simp [R.fromPoly, R.monomial]
+      /- ⊢ a + ((Ideal.Quotient.mk (Ideal.span {f q n})) ((Polynomial.monomial (2**n)) 1) + 1) = a -/
+      intros a
+      unfold irreduciblePow
+      --have hgenerator : f 2 3 = (Polynomial.monomial 8 1) + 1  := by simp [f, Polynomial.X_pow_eq_monomial]
+      have hgenerator : f q n - (1 : Polynomial (ZMod q)) = (Polynomial.monomial (R := ZMod q) (2^n : Nat) 1)  := by simp  [f, Polynomial.X_pow_eq_monomial]
+      --set_option pp.all true in
+      -- `rw` bug? or because of the workaround?
+      -- tactic 'rewrite' failed, motive is not type correct
+      rw [← hgenerator]
+      have add_congr_quotient : ((Ideal.Quotient.mk (Ideal.span {f q n})) (f q n - 1) + 1)  = ((Ideal.Quotient.mk (Ideal.span {f q n})) (f q n )) := by simp
+      rw [add_congr_quotient]
+      apply Poly.add_f_eq
+      done
+    }
+/- 'p1' depends on axioms: [propext, Classical.choice, Quot.sound, ROfZComputable_stuck_term, ROfZComputable_def] -/
+#print axioms p1
+end ExampleModulo

--- a/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
@@ -99,8 +99,8 @@ def rhs := [fhe_com q, n, hq | {
   "return" (%a) : (! R) -> ()
 }]
 
-/- 'lhs' depends on axioms: [propext, Quot.sound, Classical.choice, ROfZComputable_stuck_term] -/
-#print axioms lhs
+/--info: 'lhs' depends on axioms: [propext, Quot.sound, Classical.choice, ROfZComputable_stuck_term] -/
+#guard_msgs in #print axioms lhs
 
 /-  `x^(2^n) + a = a`, since we quotient the polynomial ring with x^(2^n) -/
 open MLIR AST in

--- a/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
@@ -77,7 +77,6 @@ This ensures three properties simultaneously:
 1. We can run it at meta time giving us the `ìmplemented_by` value
 2. It strongly normalizes creating stuck term (`ROfZComputable`)
 3. We can then `simp`it to become the value we really want (`coe z`).
-4. The `theorem ROfZComputable_eq` tells us that this is safe to do.
 -/
 
 def ROfZComputable_impl (z : ℤ) : R q n :=

--- a/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
@@ -128,7 +128,6 @@ def mkExpr (Γ : Ctxt (Ty q n)) (opStx : MLIR.AST.Op 0) :
   | "poly.const" =>
     match opStx.attrs.find_int "value" with
     | .some (v, _ty) =>
-      -- throw <| .generic s!"expected 'const' to have int attr 'value', found: {repr opStx}"
       return ⟨.polynomialLike, cstComputable v⟩
     | .none => throw <| .generic s!"expected 'const' to have int attr 'value', found: {repr opStx}"
   | "arith.const" =>


### PR DESCRIPTION
To make this example work, we need a definition of `R.ofZ` that is computable, and which is not agressively unfolded. This is ensured by our `axiom` trick.

Code peeled from pre-paper submission PR: https://github.com/opencompl/ssa/pull/196.
Code stacked on: https://github.com/opencompl/ssa/pull/234

---

Closes https://github.com/opencompl/ssa/pull/196 (This PR fully integrates the features of https://github.com/opencompl/ssa/pull/196 into main.)