### PR TITLE
refactor: make `change_mlir_context` reduce less aggressively

### DIFF
--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -12,6 +12,18 @@ section
 
 open Lean Meta Elab.Tactic Qq
 
+/-- `ctxtNf` reduces an expression of type `Ctxt _` to something in between whnf and normal form.
+`ctxtNf` recursively calls `whnf` on the tail of the list, so that the result is of the form
+  `a₀ :: a₁ :: ... :: aₙ :: [] `
+where each element `aᵢ` is not further reduced -/
+private partial def ctxtNf {α : Q(Type)} (as : Q(Ctxt $α)) : MetaM Q(Ctxt $α) := do
+  let as : Q(List $α) ← whnf as
+  match as with
+    | ~q($a :: $as) =>
+        let as ← ctxtNf as
+        return q($a :: $as)
+    | as => return as
+
 /-- Given a `V : Valuation Γ`, fully reduce the context `Γ` in the type of `V` -/
 elab "change_mlir_context " V:ident : tactic => do
   let V : Name := V.getId
@@ -28,7 +40,7 @@ elab "change_mlir_context " V:ident : tactic => do
     let _  ← assertDefEqQ Vdecl.type q(@Ctxt.Valuation $Ty $G $Γ)
 
     -- Reduce the context `Γ`
-    let Γr ← reduce Γ
+    let Γr ← ctxtNf Γ
     let Γr : Q(Ctxt $Ty) := Γr
 
     let goal ← getMainGoal


### PR DESCRIPTION
In particular, don't needlessly reduce individual types in a context

This might help mitigate an issue in #237, where we had to introduce an axiom to prevent reduction