### PR TITLE
  refactor: introduce a generic building block for dialect edsl

### DIFF
--- a/SSA/Core/MLIRSyntax/EDSL.lean
+++ b/SSA/Core/MLIRSyntax/EDSL.lean
@@ -39,7 +39,7 @@ def elabIntoCom (region : TSyntax `mlir_region) (Op : Q(Type)) {Ty : Q(Type)}
   synthesizeSyntheticMVarsNoPostponing
   let com : Q(MLIR.AST.ExceptM $Op (Σ (Γ' : Ctxt $Ty) (ty : $Ty), Com $Op Γ' ty)) ←
     withTheReader Core.Context (fun ctx => { ctx with options := ctx.options.setBool `smartUnfolding false }) do
-      withTransparency (mode := TransparencyMode.all) <|
+      withTransparency (mode := .default) <|
         return ←reduce com
   let comExpr : Expr := com
   trace[Meta] com

--- a/SSA/Core/MLIRSyntax/EDSL.lean
+++ b/SSA/Core/MLIRSyntax/EDSL.lean
@@ -1,0 +1,57 @@
+import SSA.Core.MLIRSyntax.GenericParser
+import SSA.Core.MLIRSyntax.Transform
+
+/-!
+# MLIR Dialect Domain Specific Language
+This file sets up generic glue meta-code to tie together the generic MLIR parser with the
+`Transform` mechanism, to obtain an easy way to specify a DSL that elaborates into `Com`/`Expr`
+instances for a specific dialect.
+-/
+
+namespace SSA
+
+open Qq Lean Meta Elab Term
+open MLIR.AST
+
+/--
+`elabIntoCom` is a building block for defining a dialect-specific DSL based on the geneeric MLIR
+syntax parser.
+
+For example, if `FooOp` is the type of operations of a "Foo" dialect, we can build a term elaborator
+for this dialect as follows:
+```
+elab "[foo_com| " reg:mlir_region "]" : term => SSA.elabIntoCom reg q(FooOp)
+--     ^^^^^^^                                                        ^^^^^
+```
+-/
+def elabIntoCom (region : TSyntax `mlir_region) (Op : Q(Type)) {Ty : Q(Type)}
+    (_opSignature : Q(OpSignature $Op $Ty) := by exact q(by infer_instance))
+    (φ : Q(Nat) := q(0))
+    (_transformTy      : Q(TransformTy $Op $Ty $φ)     := by exact q(by infer_instance))
+    (_transformExpr    : Q(TransformExpr $Op $Ty $φ)   := by exact q(by infer_instance))
+    (_transformReturn  : Q(TransformReturn $Op $Ty $φ) := by exact q(by infer_instance))
+    :
+    TermElabM Expr := do
+  let ast_stx ← `([mlir_region| $region])
+  let ast ← elabTermEnsuringTypeQ ast_stx q(Region $φ)
+  let com : Q(MLIR.AST.ExceptM $Op (Σ (Γ' : Ctxt $Ty) (ty : $Ty), Com $Op Γ' ty)) :=
+    q(MLIR.AST.mkCom $ast)
+  synthesizeSyntheticMVarsNoPostponing
+  let com : Q(MLIR.AST.ExceptM $Op (Σ (Γ' : Ctxt $Ty) (ty : $Ty), Com $Op Γ' ty)) ←
+    withTheReader Core.Context (fun ctx => { ctx with options := ctx.options.setBool `smartUnfolding false }) do
+      withTransparency (mode := TransparencyMode.all) <|
+        return ←reduce com
+  let comExpr : Expr := com
+  trace[Meta] com
+  trace[Meta] comExpr
+
+  match comExpr.app3? ``Except.ok with
+  | .some (_εexpr, _αexpr, aexpr) =>
+      match aexpr.app4? ``Sigma.mk with
+      | .some (_αexpr, _βexpr, _fstexpr, sndexpr) =>
+        match sndexpr.app4? ``Sigma.mk with
+        | .some (_αexpr, _βexpr, _fstexpr, sndexpr) =>
+            return sndexpr
+        | .none => throwError "Found `Except.ok (Sigma.mk _ WRONG)`, Expected (Except.ok (Sigma.mk _ (Sigma.mk _ _))"
+      | .none => throwError "Found `Except.ok WRONG`, Expected (Except.ok (Sigma.mk _ _))"
+  | .none => throwError "Expected `Except.ok`, found {comExpr}"

--- a/SSA/Core/MLIRSyntax/EDSL.lean
+++ b/SSA/Core/MLIRSyntax/EDSL.lean
@@ -37,6 +37,12 @@ def elabIntoCom (region : TSyntax `mlir_region) (Op : Q(Type)) {Ty : Q(Type)}
   let com : Q(MLIR.AST.ExceptM $Op (Σ (Γ' : Ctxt $Ty) (ty : $Ty), Com $Op Γ' ty)) :=
     q(MLIR.AST.mkCom $ast)
   synthesizeSyntheticMVarsNoPostponing
+  /-  Now reduce the term. We do this so that the resulting term will be of the form
+        `Com.lete _ <| Com.lete _ <| ... <| Com.ret _`,
+      rather than still containing the `Transform` machinery applied to a raw AST.
+      This has the side-effect of also fully reducing the expressions involved.
+      We reduce with mode `.default` so that a dialect can prevent reduction of specific parts
+      by marking those `irreducible` -/
   let com : Q(MLIR.AST.ExceptM $Op (Σ (Γ' : Ctxt $Ty) (ty : $Ty), Com $Op Γ' ty)) ←
     withTheReader Core.Context (fun ctx => { ctx with options := ctx.options.setBool `smartUnfolding false }) do
       withTransparency (mode := .default) <|

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -218,7 +218,7 @@ elab "[alive_icom (" mvars:term,* ")| " reg:mlir_region "]" : term => do
   synthesizeSyntheticMVarsNoPostponing
   let com : Q(MLIR.AST.ExceptM (MOp $φ) (Σ (Γ' : Ctxt (MTy $φ)) (ty : (MTy $φ)), Com (MOp $φ) Γ' ty)) ←
     withTheReader Core.Context (fun ctx => { ctx with options := ctx.options.setBool `smartUnfolding false }) do
-      withTransparency (mode := TransparencyMode.all) <|
+      withTransparency (mode := TransparencyMode.default) <|
         return ←reduce com
   let comExpr : Expr := com
   trace[Meta] com

--- a/SSA/Projects/PaperExamples/PaperExamples.lean
+++ b/SSA/Projects/PaperExamples/PaperExamples.lean
@@ -4,9 +4,8 @@ import Mathlib.Logic.Function.Iterate
 import SSA.Core.Framework
 import SSA.Core.Tactic
 import SSA.Core.Util
-import SSA.Core.MLIRSyntax.AST
 import SSA.Core.MLIRSyntax.GenericParser
-import SSA.Core.MLIRSyntax.Transform
+import SSA.Core.MLIRSyntax.EDSL
 import Std.Data.BitVec
 import Mathlib.Data.BitVec.Lemmas
 import Mathlib.Tactic.Ring
@@ -106,34 +105,8 @@ def mkReturn (Γ : Ctxt Ty) (opStx : MLIR.AST.Op 0) : MLIR.AST.ReaderM Op (Σ ty
 instance : MLIR.AST.TransformReturn Op Ty 0 where
   mkReturn := mkReturn
 
-def mlir2simple (reg : MLIR.AST.Region 0) :
-    MLIR.AST.ExceptM Op (Σ (Γ : Ctxt Ty) (ty : Ty), Com Op Γ ty) := MLIR.AST.mkCom reg
-
-open Qq MLIR AST Lean Elab Term Meta in
-elab "[simple_com| " reg:mlir_region "]" : term => do
-  let ast_stx ← `([mlir_region| $reg])
-  let ast ← elabTermEnsuringTypeQ ast_stx q(Region 0)
-  let mvalues ← `(⟨[], by rfl⟩)
-  -- let mvalues : Q(Vector Nat 0) ← elabTermEnsuringType mvalues q(Vector Nat 0)
-  let com := q(ToyNoRegion.MLIR2Simple.mlir2simple $ast)
-  synthesizeSyntheticMVarsNoPostponing
-  let com : Q(MLIR.AST.ExceptM Op (Σ (Γ' : Ctxt Ty) (ty : Ty), Com Op Γ' ty)) ←
-    withTheReader Core.Context (fun ctx => { ctx with options := ctx.options.setBool `smartUnfolding false }) do
-      withTransparency (mode := TransparencyMode.all) <|
-        return ←reduce com
-  let comExpr : Expr := com
-  trace[Meta] com
-  trace[Meta] comExpr
-  match comExpr.app3? ``Except.ok with
-  | .some (_εexpr, _αexpr, aexpr) =>
-      match aexpr.app4? ``Sigma.mk with
-      | .some (_αexpr, _βexpr, _fstexpr, sndexpr) =>
-        match sndexpr.app4? ``Sigma.mk with
-        | .some (_αexpr, _βexpr, _fstexpr, sndexpr) =>
-            return sndexpr
-        | .none => throwError "Found `Except.ok (Sigma.mk _ WRONG)`, Expected (Except.ok (Sigma.mk _ (Sigma.mk _ _))"
-      | .none => throwError "Found `Except.ok WRONG`, Expected (Except.ok (Sigma.mk _ _))"
-  | .none => throwError "Expected `Except.ok`, found {comExpr}"
+open Qq in
+elab "[simple_com| " reg:mlir_region "]" : term => SSA.elabIntoCom reg q(Op)
 
 end MLIR2Simple
 


### PR DESCRIPTION
Define a generic term elaborator `elabIntoCom`, which can be used to easily define dialect-specific term elaborators. For example, if `FooOp` is the type of operations of a "Foo" dialect, we can build a term elaborator for this dialect as follows:
```
elab "[foo_com| " reg:mlir_region "]" : term => SSA.elabIntoCom reg q(FooOp)
--     ^^^^^^^                                                        ^^^^^
```

This notably doesn't work for the Alive/LLVM dialect, since we have to figure out what to do with meta variables. I've tried to make that work, but it's quite complicated, so I'd like to merge the easier case first.