### PR TITLE
Apache license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,70 @@
-Copyright 2024 ssa AUTHORS
+Apache License 2.0 (Apache)
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+1. Definitions.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+1. You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+2. You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+3. You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+4. If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.

--- a/SSA.lean
+++ b/SSA.lean
@@ -1,3 +1,7 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
 -- Core
 -- ====
 import SSA.Core.Framework

--- a/SSA/Core.lean
+++ b/SSA/Core.lean
@@ -1,2 +1,5 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.Framework
 import SSA.Core.Tactic

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Data.Erased
 import Mathlib.Data.Finset.Basic
 import SSA.Core.HVector

--- a/SSA/Core/Examples.lean
+++ b/SSA/Core/Examples.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.Framework
 import SSA.Core.Tactic
 

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 -- Investigations on asymptotic behavior of representing programs with large explicit contexts
 
 import SSA.Core.ErasedContext

--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Tactic.Basic
 
 

--- a/SSA/Core/MLIRSyntax/AST.lean
+++ b/SSA/Core/MLIRSyntax/AST.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.Util.ConcreteOrMVar
 open Lean PrettyPrinter
 

--- a/SSA/Core/MLIRSyntax/EDSL.lean
+++ b/SSA/Core/MLIRSyntax/EDSL.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.MLIRSyntax.GenericParser
 import SSA.Core.MLIRSyntax.Transform
 

--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Lean
 import Lean.Elab
 import Lean.Meta

--- a/SSA/Core/MLIRSyntax/Transform.lean
+++ b/SSA/Core/MLIRSyntax/Transform.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 -- should replace with Lean import once Pure is upstream
 import SSA.Core.MLIRSyntax.AST
 import SSA.Core.MLIRSyntax.Transform.NameMapping

--- a/SSA/Core/MLIRSyntax/Transform/NameMapping.lean
+++ b/SSA/Core/MLIRSyntax/Transform/NameMapping.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Std.Data.List.Basic
 
 namespace MLIR.AST

--- a/SSA/Core/MLIRSyntax/Transform/TransformError.lean
+++ b/SSA/Core/MLIRSyntax/Transform/TransformError.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.MLIRSyntax.AST
 
 namespace MLIR.AST

--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.Framework
 import SSA.Core.Util
 import Qq

--- a/SSA/Core/Util.lean
+++ b/SSA/Core/Util.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Data.Fin.Basic
 import Mathlib.Data.Vector
 import Cli

--- a/SSA/Core/Util/ConcreteOrMVar.lean
+++ b/SSA/Core/Util/ConcreteOrMVar.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Data.Fin.Basic
 import Mathlib.Data.Vector.Basic
 -- import Mathlib.Tactic

--- a/SSA/Experimental/Bits/Decide.lean
+++ b/SSA/Experimental/Bits/Decide.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Experimental.Bits.Lemmas
 
 open Fintype Term

--- a/SSA/Experimental/Bits/Defs.lean
+++ b/SSA/Experimental/Bits/Defs.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Data.Bool.Basic
 
 inductive Term : Type

--- a/SSA/Experimental/Bits/Lemmas.lean
+++ b/SSA/Experimental/Bits/Lemmas.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Fintype.Sum
 import Mathlib.Data.Fintype.Sigma

--- a/SSA/Experimental/Bugred/InductiveFamily.lean
+++ b/SSA/Experimental/Bugred/InductiveFamily.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 abbrev Kind := Unit
 abbrev ExprKind :=  Unit
  inductive OpKind : Kind → Kind → Type

--- a/SSA/Experimental/Bugred/failed-to-generate-equality-terms.lean
+++ b/SSA/Experimental/Bugred/failed-to-generate-equality-terms.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 inductive Op where
 | op (name : String)
 

--- a/SSA/Experimental/Bugred/failed-to-generate-splitter-2.lean
+++ b/SSA/Experimental/Bugred/failed-to-generate-splitter-2.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Data.Erased
 
 inductive Ty

--- a/SSA/Experimental/Bugred/failed-to-generate-splitter.lean
+++ b/SSA/Experimental/Bugred/failed-to-generate-splitter.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 /-!
   This file was originally intended to showcase a `failed to generate splitter` error.
   In the process of minimization, that error dissapeared.

--- a/SSA/Experimental/Bugred/mutial-induction-failed-codegen-after-mathlib-include.lean
+++ b/SSA/Experimental/Bugred/mutial-induction-failed-codegen-after-mathlib-include.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Algebra.Order.Ring.Canonical
 import Mathlib.Data.Nat.Basic
 

--- a/SSA/Experimental/Bugred/slow-dependent-pattern-matching-string.lean
+++ b/SSA/Experimental/Bugred/slow-dependent-pattern-matching-string.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Data.Int.Basic
 import Mathlib.Data.Int.Lemmas
 open Mathlib

--- a/SSA/Experimental/Bugred/structured-recursion-fails-on-expr-rec.lean
+++ b/SSA/Experimental/Bugred/structured-recursion-fails-on-expr-rec.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Tactic.Linarith
 
 inductive Vector (α : Type) : Nat → Type

--- a/SSA/Experimental/MatchGoal.lean
+++ b/SSA/Experimental/MatchGoal.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Std
 import Lean.Meta.Tactic.Rewrite
 import Lean.Meta.Tactic.Refl

--- a/SSA/Experimental/PredicateTransformer.lean
+++ b/SSA/Experimental/PredicateTransformer.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Aesop
 
 namespace Hoare

--- a/SSA/Experimental/SSA2TreeNoProof.lean
+++ b/SSA/Experimental/SSA2TreeNoProof.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Tactic.Linarith
 import Aesop
 -- A translation from SSA to Tree, with no proofs.

--- a/SSA/Experimental/SSARgn2TreeNoProof.lean
+++ b/SSA/Experimental/SSARgn2TreeNoProof.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Tactic.Linarith
 import Aesop
 -- A translation from SSA + Regions to Tree, with no proofs.

--- a/SSA/Experimental/SSARgnVar2TreeNoProof.lean
+++ b/SSA/Experimental/SSARgnVar2TreeNoProof.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Tactic.Linarith
 import Aesop
 -- A translation from SSA + Regions to Tree, with no proofs.

--- a/SSA/Experimental/SSAToTree.lean
+++ b/SSA/Experimental/SSAToTree.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 -- We create a verified conversion from SSA minus Regions (ie, a sequence
 -- of let bindings) into an expression tree. We prove that this
 -- conversion preserves program semantics.

--- a/SSA/MLIRNatural.lean
+++ b/SSA/MLIRNatural.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.InstCombine.TestLLVMOps
 import SSA.Projects.InstCombine.LLVM.CLITests
 import Cli

--- a/SSA/Projects/CSE/CSE.lean
+++ b/SSA/Projects/CSE/CSE.lean
@@ -1,4 +1,7 @@
 /-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+/-
 This file implements common subexpression elimination for our SSA based IR.
 -/
 import SSA.Core.Framework

--- a/SSA/Projects/DCE/DCE.lean
+++ b/SSA/Projects/DCE/DCE.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.Framework
 import Mathlib.Tactic.Linarith
 

--- a/SSA/Projects/FullyHomomorphicEncryption.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.FullyHomomorphicEncryption.Basic
 import SSA.Projects.FullyHomomorphicEncryption.Rewrites
 import SSA.Projects.FullyHomomorphicEncryption.Statements

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -1,4 +1,7 @@
 /-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+/-
 This file contains the definition of the MLIR `Poly` dialect as implemented in HEIR, see:
 https://github.com/google/heir/blob/a18d4e8ddc0031e2a0e6dd2dd0d7fe289b9d1651/include/Dialect/Poly/IR/PolyDialect.td
 https://github.com/j2kun/heir/blob/5c5c0e2ff2ae37a7d1ec5791ec6c38046c4115c1/include/Dialect/Poly/IR/PolyOps.td

--- a/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Rewrites.lean
@@ -1,4 +1,7 @@
 /-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+/-
 End-to-end showcase of the framework for verifying rewrites about FHE semantics.
 
 Authors: Andrés Goens<andres@goens.org>

--- a/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.FullyHomomorphicEncryption.Basic
 import Std.Data.List.Lemmas
 import Mathlib.Data.List.Basic

--- a/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Syntax.lean
@@ -1,4 +1,7 @@
 /-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+/-
 Syntax definitions for FHE, providing a custom [fhe_com|...] with syntax sugar.
 
 Authors: Andrés Goens<andres@goens.org>, Siddharth Bhat<siddu.druid@gmail.com>

--- a/SSA/Projects/Holor/ForMathlib.lean
+++ b/SSA/Projects/Holor/ForMathlib.lean
@@ -1,0 +1,3 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/

--- a/SSA/Projects/Holor/Holor.lean
+++ b/SSA/Projects/Holor/Holor.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.Framework
 import SSA.Core.Util
 import Mathlib.Data.Holor

--- a/SSA/Projects/InstCombine/Alive.lean
+++ b/SSA/Projects/InstCombine/Alive.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 
 -- Pure math statements needed to prove alive statements.
 -- Include these, as they are reasonably fast to typecheck.

--- a/SSA/Projects/InstCombine/AliveAutoGenerated.lean
+++ b/SSA/Projects/InstCombine/AliveAutoGenerated.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 
 import SSA.Projects.InstCombine.LLVM.EDSL
 import SSA.Projects.InstCombine.AliveStatements

--- a/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.InstCombine.LLVM.EDSL
 import SSA.Projects.InstCombine.AliveStatements
 import SSA.Projects.InstCombine.Refinement

--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.InstCombine.TacticAuto
 import SSA.Projects.InstCombine.ForStd
 import SSA.Projects.InstCombine.ForMathlib

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 --import SSA.Core.WellTypedFramework
 import SSA.Core.Framework
 import SSA.Core.Util

--- a/SSA/Projects/InstCombine/Broken.lean
+++ b/SSA/Projects/InstCombine/Broken.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.WellTypedFramework
 import SSA.Core.Tactic
 import SSA.Projects.InstCombine.Base

--- a/SSA/Projects/InstCombine/ComWrappers.lean
+++ b/SSA/Projects/InstCombine/ComWrappers.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.InstCombine.Base
 
 /- Wrapper around Com, Expr constructors to easily hand-write IR -/

--- a/SSA/Projects/InstCombine/ForMathlib.lean
+++ b/SSA/Projects/InstCombine/ForMathlib.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Tactic.Ring
 import Mathlib.Data.BitVec.Lemmas
 

--- a/SSA/Projects/InstCombine/ForStd.lean
+++ b/SSA/Projects/InstCombine/ForStd.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 
 namespace BitVec
 

--- a/SSA/Projects/InstCombine/LLVM/CLITests.lean
+++ b/SSA/Projects/InstCombine/LLVM/CLITests.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.Util
 import Std
 import Lean.Environment

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Qq
 import SSA.Projects.InstCombine.Base
 import Std.Data.BitVec

--- a/SSA/Projects/InstCombine/LLVM/Enumerator.lean
+++ b/SSA/Projects/InstCombine/LLVM/Enumerator.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 -- Script that exhaustive enumerates the our LLVM semantics.
 import Std.Data.BitVec
 import Init.System.IO

--- a/SSA/Projects/InstCombine/LLVM/Examples.lean
+++ b/SSA/Projects/InstCombine/LLVM/Examples.lean
@@ -1,1 +1,4 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 -- See: https://github.com/llvm/llvm-project/tree/main/llvm/test/Transforms/InstCombine

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Std.Data.BitVec
 import SSA.Projects.InstCombine.ForStd
 import Mathlib.Tactic.Cases

--- a/SSA/Projects/InstCombine/LLVM/SimpSet.lean
+++ b/SSA/Projects/InstCombine/LLVM/SimpSet.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Lean.Meta.Tactic.Simp.SimpTheorems
 import Lean.Meta.Tactic.Simp.RegisterCommand
 import Lean.LabelAttribute

--- a/SSA/Projects/InstCombine/Refinement.lean
+++ b/SSA/Projects/InstCombine/Refinement.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.InstCombine.Base
 import SSA.Projects.InstCombine.LLVM.EDSL
 import SSA.Projects.InstCombine.AliveStatements

--- a/SSA/Projects/InstCombine/ScalingTest.lean
+++ b/SSA/Projects/InstCombine/ScalingTest.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 
 import SSA.Projects.InstCombine.LLVM.Semantics
 import SSA.Projects.InstCombine.Tactic

--- a/SSA/Projects/InstCombine/Slow.lean
+++ b/SSA/Projects/InstCombine/Slow.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.WellTypedFramework
 import SSA.Core.Tactic
 import SSA.Core.Util

--- a/SSA/Projects/InstCombine/Tactic.lean
+++ b/SSA/Projects/InstCombine/Tactic.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.InstCombine.LLVM.EDSL
 import SSA.Projects.InstCombine.LLVM.SimpSet
 import SSA.Projects.InstCombine.AliveStatements

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Tactic.Ring
 import Std.Data.BitVec
 import Mathlib.Data.BitVec.Lemmas

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.MLIRSyntax.GenericParser
 import SSA.Core.MLIRSyntax.Transform
 import SSA.Projects.InstCombine.LLVM.EDSL

--- a/SSA/Projects/InstCombine/TestLLVMOps.lean
+++ b/SSA/Projects/InstCombine/TestLLVMOps.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.InstCombine.LLVM.EDSL
 import SSA.Projects.InstCombine.LLVM.CLITests
 

--- a/SSA/Projects/InstCombine/Tests.lean
+++ b/SSA/Projects/InstCombine/Tests.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Projects.InstCombine.Base
 
 -- What do we have:

--- a/SSA/Projects/InstCombine/extract_alive_statements.sh
+++ b/SSA/Projects/InstCombine/extract_alive_statements.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# Released under Apache 2.0 license as described in the file LICENSE.
 
 ALIVE_FILE="Alive.lean"
 INST_COMBINE_PREFIX="SSA/Projects/InstCombine"

--- a/SSA/Projects/InstCombine/splitandprocess.py
+++ b/SSA/Projects/InstCombine/splitandprocess.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Released under Apache 2.0 license as described in the file LICENSE.
 
 def getProofs(lines):
     proofs = []

--- a/SSA/Projects/PaperExamples/PaperExamples.lean
+++ b/SSA/Projects/PaperExamples/PaperExamples.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Qq
 import Lean
 import Mathlib.Logic.Function.Iterate

--- a/SSA/Projects/Scf/ScfFunctor.lean
+++ b/SSA/Projects/Scf/ScfFunctor.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Logic.Function.Iterate
 import Mathlib.Tactic.Linarith

--- a/SSA/Projects/Tensor1D/Tensor1D.lean
+++ b/SSA/Projects/Tensor1D/Tensor1D.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.Framework
 import SSA.Core.Util
 import Mathlib.Tactic.Linarith

--- a/SSA/Projects/Tensor2D/ForMathlib.lean
+++ b/SSA/Projects/Tensor2D/ForMathlib.lean
@@ -1,0 +1,3 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/

--- a/SSA/Projects/Tensor2D/Tensor2D.lean
+++ b/SSA/Projects/Tensor2D/Tensor2D.lean
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import SSA.Core.Framework
 import SSA.Core.Util
 import Mathlib.Tactic.Linarith

--- a/test/LLVMDialect/LLVM/convert-to-mlir.sh
+++ b/test/LLVMDialect/LLVM/convert-to-mlir.sh
@@ -1,7 +1,6 @@
-/-
-Released under Apache 2.0 license as described in the file LICENSE.
--/
 #!/bin/bash
+# Released under Apache 2.0 license as described in the file LICENSE.
+
 
 #Using LLVM commit 55300991b5ed574812db318742fd0de3887b54dd
 FOLDERS="InstCombine"

--- a/test/LLVMDialect/LLVM/convert-to-mlir.sh
+++ b/test/LLVMDialect/LLVM/convert-to-mlir.sh
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 #!/bin/bash
 
 #Using LLVM commit 55300991b5ed574812db318742fd0de3887b54dd

--- a/test/bruteforce-correctness/llvm.py
+++ b/test/bruteforce-correctness/llvm.py
@@ -1,8 +1,7 @@
-/-
-Released under Apache 2.0 license as described in the file LICENSE.
--/
 #!/usr/bin/env python3
 # Generate the file for LLVM
+# Released under Apache 2.0 license as described in the file LICENSE.
+
 import itertools
 from typing import *
 import subprocess

--- a/test/bruteforce-correctness/llvm.py
+++ b/test/bruteforce-correctness/llvm.py
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 #!/usr/bin/env python3
 # Generate the file for LLVM
 import itertools

--- a/test/bruteforce-correctness/run.sh
+++ b/test/bruteforce-correctness/run.sh
@@ -1,7 +1,6 @@
-/-
-Released under Apache 2.0 license as described in the file LICENSE.
--/
 #!/usr/bin/env bash
+# Released under Apache 2.0 license as described in the file LICENSE.
+
 set -e
 set -o xtrace
 rm generated* || true # don't error if no files are removed

--- a/test/bruteforce-correctness/run.sh
+++ b/test/bruteforce-correctness/run.sh
@@ -1,3 +1,6 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 #!/usr/bin/env bash
 set -e
 set -o xtrace


### PR DESCRIPTION
We accurately track the page with the `LICENSE` information, and we move from the MIT license to the Apache 2 license.

To accept this PR, we should receive acknowledgement from everyone who has contributed code into our repository. 