### PR TITLE
chore: drop two unnecessary lemmas from simp_peephole

### DIFF
--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -49,20 +49,6 @@ elab "change_mlir_context " V:ident : tactic => do
 
 end
 
-@[simp]
-private theorem Ctxt.destruct_cons {Ty} [TyDenote Ty] {Γ : Ctxt Ty} {t : Ty} {f : Ctxt.Valuation (t :: Γ) → Prop} :
-    (∀ V, f V) ↔ (∀ (a : ⟦t⟧) (V : Γ.Valuation), f (V.snoc a)) := by
-  constructor
-  · intro h a V; apply h
-  · intro h V; cases V; apply h
-
-@[simp]
-private theorem Ctxt.destruct_nil {Ty} [TyDenote Ty] {f : Ctxt.Valuation ([] : Ctxt Ty) → Prop} :
-    (∀ V, f V) ↔ (f Ctxt.Valuation.nil) := by
-  constructor
-  · intro h; apply h
-  · intro h V; rw [Ctxt.Valuation.eq_nil V]; exact h
-
 open Lean Elab Tactic Meta
 
 /--
@@ -126,7 +112,6 @@ macro "simp_peephole" "[" ts: Lean.Parser.Tactic.simpLemma,* "]" "at" ll:ident :
         OpDenote.denote, Expr.op_mk, Expr.args_mk,
         DialectMorphism.mapOp, DialectMorphism.mapTy, List.map, Ctxt.snoc, List.map,
         Function.comp, Valuation.ofPair, Valuation.ofHVector, Function.uncurry,
-        Ctxt.destruct_cons, Ctxt.destruct_nil,
         List.length_singleton, Fin.zero_eta, List.map_eq_map, List.map_cons, List.map_nil,
         bind_assoc, pairBind,
         $ts,*]


### PR DESCRIPTION
These were added in 121e9c7fa316edf8fc1824da136cb6a2cb3ba08c in an attempt to reduce the delta of the FHE branch, but were really not needed.