### PR TITLE
change: redefine alive dsl in terms of generic `elabIntoCom`

### DIFF
--- a/SSA/Core/MLIRSyntax/EDSL.lean
+++ b/SSA/Core/MLIRSyntax/EDSL.lean
@@ -13,6 +13,35 @@ namespace SSA
 open Qq Lean Meta Elab Term
 open MLIR.AST
 
+/-- `ctxtNf` reduces an expression of type `Ctxt _` to something in between whnf and normal form.
+`ctxtNf` recursively calls `whnf` on the tail of the list, so that the result is of the form
+  `a₀ :: a₁ :: ... :: aₙ :: [] `
+where each element `aᵢ` is not further reduced -/
+partial def ctxtNf (as : Expr) : MetaM Expr := do
+  let as ← whnf as
+  match_expr as with
+    | List.cons _ a as =>
+        let as ← ctxtNf as
+        mkAppM ``Ctxt.snoc #[as, a]
+    | _ => return as
+
+/-- `comNf` reduces an expression of type `Com` to something in between whnf and normal form.
+`comNf` recursively calls `whnf` on the expression and body of a `Com.lete`, resulting in
+  `Com.lete (Expr.mk ...) <| Com.lete (Expr.mk ...) <| Com.lete (Expr.mk ...) <| ... <| Com.rete _`
+where the arguments to `Expr.mk` are not reduced -/
+partial def comNf (com : Expr) : MetaM Expr := do
+  let com ← whnf com
+  match_expr com with
+    | Com.lete Op Ty opSig Γ α β e body =>
+        let Γ ← ctxtNf Γ
+        let α ← whnf α
+        let β ← whnf β
+        let e ← whnf e
+        let body ← comNf body
+        return mkAppN (.const ``Com.lete []) #[Op, Ty, opSig, Γ, α, β, e, body]
+    | Com.ret _Op _Ty _inst _Γ _t _ => return com
+    | _ => throwError "Expected `Com.lete _ _` or `Com.ret _`, found:\n\t{com}"
+
 /--
 `elabIntoCom` is a building block for defining a dialect-specific DSL based on the geneeric MLIR
 syntax parser.
@@ -24,40 +53,33 @@ elab "[foo_com| " reg:mlir_region "]" : term => SSA.elabIntoCom reg q(FooOp)
 --     ^^^^^^^                                                        ^^^^^
 ```
 -/
-def elabIntoCom (region : TSyntax `mlir_region) (Op : Q(Type)) {Ty : Q(Type)}
+def elabIntoCom (region : TSyntax `mlir_region) (Op : Q(Type)) {Ty : Q(Type)} {φ : Q(Nat)}
     (_opSignature : Q(OpSignature $Op $Ty) := by exact q(by infer_instance))
-    (φ : Q(Nat) := q(0))
     (_transformTy      : Q(TransformTy $Op $Ty $φ)     := by exact q(by infer_instance))
     (_transformExpr    : Q(TransformExpr $Op $Ty $φ)   := by exact q(by infer_instance))
-    (_transformReturn  : Q(TransformReturn $Op $Ty $φ) := by exact q(by infer_instance))
-    :
+    (_transformReturn  : Q(TransformReturn $Op $Ty $φ) := by exact q(by infer_instance)) :
     TermElabM Expr := do
   let ast_stx ← `([mlir_region| $region])
   let ast ← elabTermEnsuringTypeQ ast_stx q(Region $φ)
-  let com : Q(MLIR.AST.ExceptM $Op (Σ (Γ' : Ctxt $Ty) (ty : $Ty), Com $Op Γ' ty)) :=
+  let com : Q(ExceptM $Op (Σ (Γ' : Ctxt $Ty) (ty : $Ty), Com $Op Γ' ty)) :=
     q(MLIR.AST.mkCom $ast)
   synthesizeSyntheticMVarsNoPostponing
-  /-  Now reduce the term. We do this so that the resulting term will be of the form
-        `Com.lete _ <| Com.lete _ <| ... <| Com.ret _`,
-      rather than still containing the `Transform` machinery applied to a raw AST.
-      This has the side-effect of also fully reducing the expressions involved.
-      We reduce with mode `.default` so that a dialect can prevent reduction of specific parts
-      by marking those `irreducible` -/
-  let com : Q(MLIR.AST.ExceptM $Op (Σ (Γ' : Ctxt $Ty) (ty : $Ty), Com $Op Γ' ty)) ←
-    withTheReader Core.Context (fun ctx => { ctx with options := ctx.options.setBool `smartUnfolding false }) do
-      withTransparency (mode := .default) <|
-        return ←reduce com
-  let comExpr : Expr := com
-  trace[Meta] com
-  trace[Meta] comExpr
-
-  match comExpr.app3? ``Except.ok with
-  | .some (_εexpr, _αexpr, aexpr) =>
-      match aexpr.app4? ``Sigma.mk with
-      | .some (_αexpr, _βexpr, _fstexpr, sndexpr) =>
-        match sndexpr.app4? ``Sigma.mk with
-        | .some (_αexpr, _βexpr, _fstexpr, sndexpr) =>
-            return sndexpr
+  /- Now we repeatedly call `whnf` and then match on the resulting expression, to extract an
+    expression of type `Com ..` -/
+  let com : Q(ExceptM $Op (Σ (Γ' : Ctxt $Ty) (ty : $Ty), Com $Op Γ' ty)) ← whnf com
+  match com.app3? ``Except.ok with
+  | .some (_εexpr, _αexpr, expr) =>
+      let (expr : Q(Σ Γ ty, Com $Op Γ ty)) ← whnf expr
+      match expr.app4? ``Sigma.mk with
+      | .some (_αexpr, _βexpr, (_Γ : Q(Ctxt $Ty)), expr) =>
+        let (expr : Q(Σ ty, Com $Op $_Γ ty)) ← whnf expr
+        match expr.app4? ``Sigma.mk with
+        | .some (_αexpr, _βexpr, (_ty : Q($Ty)), (com : Q(Com $Op $_Γ $_ty))) =>
+            /- Finally, use `comNf` to ensure the resulting expression is of the form
+                `Com.lete (Expr.mk ...) <| Com.lete (Expr.mk ...) ... <| Com.rete _`,
+              where the arguments to `Expr.mk` are not reduced -/
+            withTraceNode `elabIntoCom (return m!"{exceptEmoji ·} reducing `Com` expression") <|
+              comNf com
         | .none => throwError "Found `Except.ok (Sigma.mk _ WRONG)`, Expected (Except.ok (Sigma.mk _ (Sigma.mk _ _))"
-      | .none => throwError "Found `Except.ok WRONG`, Expected (Except.ok (Sigma.mk _ _))"
-  | .none => throwError "Expected `Except.ok`, found {comExpr}"
+      | .none => throwError "Expected (Sigma.mk _ _), found {expr}"
+  | .none => throwError "Expected `Except.ok`, found {com}"

--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -1,5 +1,6 @@
 import SSA.Core.Framework
 import SSA.Core.Util
+import SSA.Core.MLIRSyntax.EDSL
 import Qq
 import Lean.Meta.KAbstract
 import Lean.Elab.Tactic.ElabTerm
@@ -11,18 +12,6 @@ open Ctxt (Var Valuation DerivedCtxt)
 section
 
 open Lean Meta Elab.Tactic Qq
-
-/-- `ctxtNf` reduces an expression of type `Ctxt _` to something in between whnf and normal form.
-`ctxtNf` recursively calls `whnf` on the tail of the list, so that the result is of the form
-  `a₀ :: a₁ :: ... :: aₙ :: [] `
-where each element `aᵢ` is not further reduced -/
-private partial def ctxtNf {α : Q(Type)} (as : Q(Ctxt $α)) : MetaM Q(Ctxt $α) := do
-  let as : Q(List $α) ← whnf as
-  match as with
-    | ~q($a :: $as) =>
-        let as ← ctxtNf as
-        return q($a :: $as)
-    | as => return as
 
 /-- Given a `V : Valuation Γ`, fully reduce the context `Γ` in the type of `V` -/
 elab "change_mlir_context " V:ident : tactic => do


### PR DESCRIPTION
This PR uses `elabIntoCom` to simplify the definition of `alive_com`. This means first `elabIntoCom` will normalize the `Com` (which still has object metavariables), and only afterwards do we instantiate the metavariables and reduce it *again*.

To reduce the impact of this double reduction, we also weaken the reduction done by `elabIntoCom` analogously to `ctxtNf`; we recursively call `whnf` on the body of a `Com.lete`, instead of fully reducing. This is enought for `FHE` and `PaperExamples`. Alive, however, does need full reduction to get rid of the meta-var instantiation code, so the second reduction in `alive_com` is still `reduce`.

Minor testing suggests this version of `alive_com` is still faster than what we currenlty have in main: `and_sequence_30_lhs` (of `ScalingTest`) in the current branch takes about 175000 heartbeats compared to 210000 in main (9305ece)