### PR TITLE
Change our use of Functor.map (via <$>) to a more targeted use of ..

### DIFF
--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -503,12 +503,17 @@ theorem Lets.denote_getExpr {Γ₁ Γ₂ : Ctxt Ty} : {lets : Lets Op Γ₁ Γ�
 
 section Map
 
+def RegionSignature.map (f : Ty → Ty') : RegionSignature Ty → RegionSignature Ty' :=
+  List.map fun ⟨Γ, ty⟩ => (Γ.map f, f ty)
+
 instance : Functor RegionSignature where
-  map f := List.map fun (tys, ty) => (f <$> tys, f ty)
+  map := RegionSignature.map
+
+def Signature.map (f : Ty → Ty') : Signature Ty → Signature Ty' :=
+  fun ⟨sig, regSig, outTy⟩ => ⟨sig.map f, regSig.map f, f outTy⟩
 
 instance : Functor Signature where
-  map := fun f ⟨sig, regSig, outTy⟩ =>
-    ⟨f <$> sig, f <$> regSig, f outTy⟩
+  map := Signature.map
 
 /-- A dialect morphism consists of a map between operations and a map between types,
   such that the signature of operations is respected
@@ -516,19 +521,17 @@ instance : Functor Signature where
 structure DialectMorphism (Op Op' : Type) {Ty Ty' : Type} [OpSignature Op Ty] [OpSignature Op' Ty'] where
   mapOp : Op → Op'
   mapTy : Ty → Ty'
-  preserves_signature : ∀ op, signature (mapOp op) = mapTy <$> (signature op)
+  preserves_signature : ∀ op, signature (mapOp op) = (signature op).map mapTy
 
 variable {Op Op' Ty Ty : Type} [OpSignature Op Ty] [OpSignature Op' Ty']
   (f : DialectMorphism Op Op')
 
 def DialectMorphism.preserves_sig (op : Op) :
-    OpSignature.sig (f.mapOp op) = f.mapTy <$> (OpSignature.sig op) := by
+    OpSignature.sig (f.mapOp op) = (OpSignature.sig op).map f.mapTy  := by
   simp only [OpSignature.sig, Function.comp_apply, f.preserves_signature, List.map_eq_map]; rfl
 
 def DialectMorphism.preserves_regSig (op : Op) :
-    OpSignature.regSig (f.mapOp op) = (OpSignature.regSig op).map (
-      fun ⟨a, b⟩ => ⟨f.mapTy <$> a, f.mapTy b⟩
-    ) := by
+    OpSignature.regSig (f.mapOp op) = (OpSignature.regSig op).map f.mapTy := by
   simp only [OpSignature.regSig, Function.comp_apply, f.preserves_signature, List.map_eq_map]; rfl
 
 def DialectMorphism.preserves_outTy (op : Op) :
@@ -536,7 +539,7 @@ def DialectMorphism.preserves_outTy (op : Op) :
   simp only [OpSignature.outTy, Function.comp_apply, f.preserves_signature]; rfl
 
 mutual
-  def Com.map : Com Op Γ ty → Com Op' (f.mapTy <$> Γ) (f.mapTy ty)
+  def Com.map : Com Op Γ ty → Com Op' (Γ.map f.mapTy) (f.mapTy ty)
     | .ret v          => .ret v.toMap
     | .lete body rest => .lete body.map rest.map
 
@@ -552,7 +555,7 @@ mutual
   /-- Inline of `HVector.map'` for the termination checker -/
   def HVector.mapDialectMorphism : ∀ {regSig : RegionSignature Ty},
       HVector (fun t => Com Op t.fst t.snd) regSig
-      → HVector (fun t => Com Op' t.fst t.snd) (f.mapTy <$> regSig : RegionSignature _)
+      → HVector (fun t => Com Op' t.fst t.snd) (regSig.map f.mapTy : RegionSignature _)
     | _, .nil        => .nil
     | t::_, .cons a as  => .cons a.map (HVector.mapDialectMorphism as)
 end

--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -98,7 +98,7 @@ macro "simp_peephole" "[" ts: Lean.Parser.Tactic.simpLemma,* "]" "at" Γv:ident 
         Int.ofNat_eq_coe, Nat.cast_zero, DerivedCtxt.snoc, DerivedCtxt.ofCtxt,
         DerivedCtxt.ofCtxt_empty, Valuation.snoc_last,
         Com.denote, Expr.denote, HVector.denote, Var.zero_eq_last, Var.succ_eq_toSnoc,
-        Ctxt.empty, Ctxt.empty_eq, Ctxt.snoc, Ctxt.Valuation.nil, Ctxt.Valuation.snoc_last,
+        Ctxt.empty, Ctxt.empty_eq, Ctxt.snoc, Ctxt.Valuation.nil, Ctxt.Valuation.snoc_last, Ctxt.map,
         Ctxt.Valuation.snoc_eval, Ctxt.ofList, Ctxt.Valuation.snoc_toSnoc,
         HVector.map, HVector.getN, HVector.get, HVector.toSingle, HVector.toPair, HVector.toTuple,
         OpDenote.denote, Expr.op_mk, Expr.args_mk,

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -190,7 +190,8 @@ def MOp.instantiateCom (vals : Vector Nat φ) : DialectMorphism (MOp φ) (InstCo
       simp only [instantiateMTy, instantiateMOp, ConcreteOrMVar.instantiate, (· <$> ·), signature,
       InstCombine.MOp.sig, InstCombine.MOp.outTy, Function.comp_apply, List.map, Signature.mk.injEq,
       List.map_cons, List.map_nil, and_self, MTy.bitvec,
-      List.cons.injEq, MTy.bitvec.injEq, and_true, true_and, h1]
+      List.cons.injEq, MTy.bitvec.injEq, and_true, true_and,
+      RegionSignature.map, Signature.map, h1]
 
 open InstCombine (Op Ty) in
 def mkComInstantiate (reg : MLIR.AST.Region φ) :


### PR DESCRIPTION
RegionSignature.map and Signature.map. This makes proof states easier to read, and allows for unfolding one of the instances of Functor.map at a time.

This is pulled out of https://github.com/opencompl/ssa/pull/225 as an independent useful change.

Co-authored-by: Siddharth Bhat <siddu.druid@gmail.com>