### PR TITLE
feat: do not leak the type definition in alive

### DIFF
--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -65,7 +65,7 @@ def BitVec.width {n : Nat} (_ : BitVec n) : Nat := n
 
 instance : TyDenote Ty where
 toType := fun
-  | .bitvec w => Option <| BitVec w
+  | .bitvec w => LLVM.IntW w
 
 instance (ty : Ty) : Coe ℤ (TyDenote.toType ty) where
   coe z := match ty with
@@ -73,7 +73,7 @@ instance (ty : Ty) : Coe ℤ (TyDenote.toType ty) where
 
 instance (ty : Ty) : Inhabited (TyDenote.toType ty) where
   default := match ty with
-    | .bitvec _ => default
+    | .bitvec _ => pure default
 
 instance : Repr (BitVec n) where
   reprPrec

--- a/SSA/Projects/InstCombine/LLVM/Enumerator.lean
+++ b/SSA/Projects/InstCombine/LLVM/Enumerator.lean
@@ -152,8 +152,8 @@ def concreteCliTestRows (test : ConcreteCliTest) : IO <| Array Row := do
         let ty : InstCombine.MTy 0 := test.ty
         match hty : ty with
           | .bitvec (.concrete w) =>
-              let h : TyDenote.toType ty = Option (Std.BitVec w) := by simp [hty, TyDenote.toType]
-              let retv' : Option (Std.BitVec w) := h ▸ retv
+              let h : TyDenote.toType ty = Option (BitVec w) := by simp [hty, TyDenote.toType, LLVM.IntW]
+              let retv' : Option (BitVec w) := h ▸ retv
               let retv := BitVec.outputToString retv'
               let row : Row := {
                 opName := s!"{testNameToRowName test.name.toString}",

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -12,7 +12,7 @@ import SSA.Projects.InstCombine.LLVM.SimpSet
 namespace LLVM
 
 
-abbrev IntW w := Option <| BitVec w
+def IntW w := Option <| BitVec w
 
 /--
 The ‘and’ instruction returns the bitwise logical and of its two operands.
@@ -153,7 +153,7 @@ at width 2, -4 / -1 is considered overflow!
 def sdiv? {w : Nat} (x y : BitVec w) : IntW w :=
   if y == 0 || (w != 1 && x == (intMin w) && y == -1)
   then .none
-  else BitVec.sdiv x y
+  else pure (BitVec.sdiv x y)
 
 @[simp_llvm_option]
 def sdiv {w : Nat} (x y : IntW w) : IntW w := do


### PR DESCRIPTION
This change ensures that simp_alive_ssa does not unfold the type definition of LLVM bitvectors, such that our semantics do not leak before we unfold them.