### PR TITLE
feat: upstream a handwritten proof for alive - alive_DivRemOfSelectLarge proofs one

### DIFF
--- a/SSA/Projects/InstCombine/Alive.lean
+++ b/SSA/Projects/InstCombine/Alive.lean
@@ -10,6 +10,7 @@ import SSA.Projects.InstCombine.AliveStatements
 -- This has those examples from alive that failed to be
 -- translated correctly due to bugs in the translator.
 import SSA.Projects.InstCombine.AliveHandwrittenExamples
+import SSA.Projects.InstCombine.AliveHandwrittenLargeExamples
 
 -- The semantics for the MLIR base dialect
 import SSA.Projects.InstCombine.Base

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -39,19 +39,11 @@ theorem alive_DivRemOfSelect (w : Nat) :
   simp_alive_undef
   simp [simp_llvm]
   intro y c x
-  cases c
+  rcases c with (rfl | ⟨vcond, hcond⟩)
   -- | select condition is itself `none`, nothing more to be done. propagate the `none`.
-  case none => cases x <;> cases y <;> simp
-  case some cond =>
-     obtain ⟨vcond, hcond⟩ := cond
-     obtain (h | h) : vcond = 1 ∨ vcond = 0 := by
-       norm_num at hcond
-       rcases vcond with zero | vcond <;> simp;
-       rcases vcond with zero | vcond <;> simp;
-       linarith
-     . subst h
-       simp
-     . subst h; simp
+  · cases x <;> cases y <;> simp
+  · simp at hcond
+    (obtain (rfl | rfl) : vcond = 1 ∨ vcond = 0 := by omega) <;> simp
 
 /--info: 'AliveHandwritten.DivRemOfSelect.alive_DivRemOfSelect' depends on
 axioms: [propext, Classical.choice, Quot.sound] -/

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -37,7 +37,7 @@ theorem alive_DivRemOfSelect (w : Nat) :
   unfold alive_DivRemOfSelect_src alive_DivRemOfSelect_tgt
   simp_alive_ssa
   simp_alive_undef
-  simp [simp_llvm]
+  simp only [simp_llvm]
   rintro y (rfl | ⟨vcond, hcond⟩) x
   -- | select condition is itself `none`, nothing more to be done. propagate the `none`.
   · cases x <;> cases y <;> simp

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -38,8 +38,7 @@ theorem alive_DivRemOfSelect (w : Nat) :
   simp_alive_ssa
   simp_alive_undef
   simp [simp_llvm]
-  intro y c x
-  rcases c with (rfl | ⟨vcond, hcond⟩)
+  rintro y (rfl | ⟨vcond, hcond⟩) x
   -- | select condition is itself `none`, nothing more to be done. propagate the `none`.
   · cases x <;> cases y <;> simp
   · simp at hcond

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -1,0 +1,62 @@
+import SSA.Projects.InstCombine.LLVM.EDSL
+import SSA.Projects.InstCombine.Tactic
+
+open BitVec
+open MLIR AST
+
+namespace AliveHandwritten
+
+namespace DivRemOfSelect
+
+/--
+Name: SimplifyDivRemOfSelect
+precondition: true
+%sel = select %c, %Y, 0
+%r = udiv %X, %sel
+  =>
+%r = udiv %X, %Y
+-/
+def alive_DivRemOfSelect_src (w : Nat) :=
+  [alive_icom (w)| {
+  ^bb0(%c: i1, %y : _, %x : _):
+    %c0 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
+    %v1 = "llvm.select" (%c,%y, %c0) : (i1, _, _) -> (_)
+    %v2 = "llvm.udiv"(%x, %v1) : (_, _) -> (_)
+    "llvm.return" (%v2) : (_) -> ()
+  }]
+
+def alive_DivRemOfSelect_tgt (w : Nat) :=
+  [alive_icom (w)| {
+  ^bb0(%c: i1, %y : _, %x : _):
+    %v1 = "llvm.udiv" (%x,%y) : (_, _) -> (_)
+    "llvm.return" (%v1) : (_) -> ()
+  }]
+
+theorem alive_DivRemOfSelect (w : Nat) :
+    alive_DivRemOfSelect_src w ⊑ alive_DivRemOfSelect_tgt w := by
+  unfold alive_DivRemOfSelect_src alive_DivRemOfSelect_tgt
+  simp_alive_ssa
+  simp_alive_undef
+  simp [simp_llvm]
+  intro y c x
+  cases c
+  -- | select condition is itself `none`, nothing more to be done. propagate the `none`.
+  case none => cases x <;> cases y <;> simp
+  case some cond =>
+     obtain ⟨vcond, hcond⟩ := cond
+     obtain (h | h) : vcond = 1 ∨ vcond = 0 := by
+       norm_num at hcond
+       rcases vcond with zero | vcond <;> simp;
+       rcases vcond with zero | vcond <;> simp;
+       linarith
+     . subst h
+       simp
+     . subst h; simp
+
+/--info: 'AliveHandwritten.DivRemOfSelect.alive_DivRemOfSelect' depends on
+axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms alive_DivRemOfSelect
+
+end DivRemOfSelect
+
+end AliveHandwritten


### PR DESCRIPTION
This proof is factored out of https://github.com/opencompl/ssa/pull/167 and is part of a collection of proofs that we manually wrote to demonstrate the status of leans automation in BitVectors and such.