### PR TITLE
feat: implement 'opt' entrypoint to parse MLIR from files. (#102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           lake -R exe cache get # download cache of mathlib docs.
           lake -R build AliveScaling
 
-      - name: Compile Executable 🧐
+      - name: Compile `mlirnatural` Executable 🧐
         run: |
           lake -R exe cache get # download cache of mathlib docs.
           lake -R build mlirnatural
@@ -47,7 +47,16 @@ jobs:
       - name: LLVM Exhaustive Enumeration
         run: |
           sudo apt install llvm-15 # for opt-15, used to simplify LLVM for reference semantics.
-          cd test/bruteforce-correctness && ./run.sh
+          (cd test/bruteforce-correctness && ./run.sh)
+
+      - name: Compile `opt` Executable 🧐
+        run: |
+          lake -R exe cache get # download cache of mathlib docs.
+          lake -R build opt
+
+      - name: LLVM opt round trip test
+        run: |
+          lake exec opt test/LLVMDialect/InstCombine/bb0.mlir
 
       - name: Check for changes in AliveStatements
         run: |

--- a/SSA/Core/MLIRSyntax.lean
+++ b/SSA/Core/MLIRSyntax.lean
@@ -3,6 +3,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import SSA.Core.MLIRSyntax.AST
 import SSA.Core.MLIRSyntax.EDSL
+import SSA.Core.MLIRSyntax.Parser
 import SSA.Core.MLIRSyntax.GenericParser
 import SSA.Core.MLIRSyntax.Transform
 

--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -283,7 +283,6 @@ syntax ident: mlir_type
 syntax "_" : mlir_type
 
 
-set_option hygiene false in -- allow i to expand
 macro_rules
   | `([mlir_type| $x:ident ]) => do
         let xstr := x.getId.toString
@@ -447,18 +446,20 @@ syntax  "{" ("^" ident ("(" sepBy(mlir_bb_operand, ",") ")")? ":")? mlir_ops "}"
 syntax "[mlir_region|" mlir_region "]": term
 
 macro_rules
-| `([mlir_region| { ^ $name:ident ( $operands,* ) : $ops }  ]) => do
+| `(mlir_region| { ^ $name:ident ( $operands,* ) : $ops }) => do
    let initList <- `(@List.nil (MLIR.AST.SSAVal × MLIR.AST.MLIRType _))
    let argsList <- operands.getElems.foldrM (init := initList) fun x xs => `([mlir_bb_operand| $x] :: $xs)
    let opsList <- `([mlir_ops| $ops])
    `(Region.mk $(Lean.quote (name.getId.toString)) $argsList $opsList)
-| `([mlir_region| {  ^ $name:ident : $ops } ]) => do
+| `(mlir_region| {  ^ $name:ident : $ops } ) => do
    let opsList <- `([mlir_ops| $ops])
    `(Region.mk $(Lean.quote (name.getId.toString)) [] $opsList)
-| `([mlir_region| { $ops:mlir_ops } ]) => do
+| `(mlir_region| { $ops:mlir_ops }) => do
    let opsList <- `([mlir_ops| $ops])
    `(Region.mk "entry" [] $opsList)
 
+macro_rules
+| `([mlir_region| $q:mlir_region ]) => `(mlir_region| $q)
 
 macro_rules
 | `([mlir_region| $$($q) ]) => return q

--- a/SSA/Core/MLIRSyntax/Parser.lean
+++ b/SSA/Core/MLIRSyntax/Parser.lean
@@ -1,0 +1,135 @@
+import SSA.Core.MLIRSyntax.AST
+import SSA.Core.MLIRSyntax.EDSL
+import Lean
+/- Parse  a raw file into `MLIR.AST.*` constructs. -/
+open Lean
+
+variable {ParseOutput : Type} [ToString ParseOutput]
+
+abbrev ParseError := String
+abbrev ParseFun : Type := Lean.Environment → String → EIO ParseError ParseOutput
+
+-- We use unification with `isDefEq` to find the synthetic metavariables, and then we synthesize and instantiate them
+-- This lets us instantiate arguments like the `Nat` argument to `MLIR.AST.Region`.
+-- For more info, see: https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Calling.20unification.20from.20meta.20to.20remove.20metavariables
+unsafe def elabIntoTermTactic {α : Type} (expectedType : Expr) (stx : Lean.Syntax) : Elab.Tactic.TacticM α := do
+  let expr ← Lean.Elab.Tactic.elabTerm stx none
+  let _ ← Meta.isDefEq (← Meta.inferType expr) expectedType
+  Elab.Term.synthesizeSyntheticMVarsNoPostponing
+  let expr ← instantiateMVars expr
+  Meta.evalExpr α expectedType expr
+
+namespace Lean.Elab.Tactic
+
+@[inline] private def TacticM.runCore (x : TacticM α) (ctx : Context) (s : State) : TermElabM (α × State) :=
+  x ctx |>.run s
+
+@[inline] private def TacticM.runCore' (x : TacticM α) (ctx : Context) (s : State) : TermElabM α :=
+  Prod.fst <$> x.runCore ctx s
+
+end Lean.Elab.Tactic
+
+unsafe def elabIntoTermElab {α : Type} (expectedType : Expr) (stx : Lean.Syntax) : Elab.Term.TermElabM α := do
+  elabIntoTermTactic (α := α) expectedType stx  |>.runCore' { elaborator := `ParserHack} default
+
+unsafe def elabIntoMeta {α : Type} (expectedType : Expr) (stx : Lean.Syntax) : MetaM α :=
+  elabIntoTermElab (α := α) expectedType stx |>.run'
+
+unsafe def elabIntoCore {α : Type} (expectedType : Expr) (stx : Lean.Syntax) : CoreM α :=
+  elabIntoMeta (α := α) expectedType stx |>.run'
+
+def printException : Except Exception α → IO String
+  | Except.ok _ => throw <| IO.userError "printException called on Except.ok"
+  | Except.error e => e.toMessageData.toString
+
+unsafe def elabIntoEIO {α : Type} (env : Lean.Environment) (typeName : Lean.Expr) (stx : Lean.Syntax) : EIO ParseError α :=
+  fun s =>
+    let resE : EIO Exception α := elabIntoCore (α := α) typeName stx |>.run' {fileName := "parserHack", fileMap := default} {env := env}
+    match resE s with
+    | .ok a s => .ok a s
+    | .error exception s =>
+      let errMsgIO : IO String := exception.toMessageData.toString
+      match errMsgIO s with
+      | .ok errMsg s => .error s!"failed elaboration {stx}. Error: {errMsg}" s
+      | .error e s => .error s!" Failed elaborating {stx}.\nUnable to pretty-print exception at 'elabIntoEIO':\n{e}." s
+
+def region0Expr := (Expr.app (Expr.const `MLIR.AST.Region []) (Expr.const `Nat.zero []))
+
+def op0Expr := (Expr.app (Expr.const `MLIR.AST.Op []) (Expr.const `Nat.zero []))
+/--
+  Parse `Lean.Syntax` into `MLIR.AST.Region`.
+
+  This runs the Lean frontend stack and adds it to the TCB.
+  It should be safe (if we trust the lean parser) since we ensure that the types match: see
+  https://leanprover-community.github.io/mathlib4_docs/Std/Util/TermUnsafe.html#Std.TermUnsafe.termUnsafe_
+ -/
+def elabRegion (env : Lean.Environment) (stx : Lean.Syntax) : EIO ParseError (MLIR.AST.Region 0) := do
+  let reg ← unsafe elabIntoEIO (α := MLIR.AST.Region 0) env region0Expr stx
+  return reg
+
+/--
+  Parse `Lean.Syntax` into `MLIR.AST.Op`.
+
+  This runs the Lean frontend stack and adds it to the TCB.
+  It should be safe (if we trust the lean parser) since we ensure that the types match: see
+  https://leanprover-community.github.io/mathlib4_docs/Std/Util/TermUnsafe.html#Std.TermUnsafe.termUnsafe_
+ -/
+def elabOp (env : Lean.Environment) (stx : Lean.Syntax) : EIO ParseError (MLIR.AST.Op 0) :=
+  unsafe elabIntoEIO (α := MLIR.AST.Op 0) env op0Expr stx
+
+def mkParseFun (syntaxcat : Name)
+    (ntparser : Syntax → EIO ParseError ParseOutput)
+    (s : String) (env : Environment) : EIO ParseError ParseOutput := do
+  match Parser.runParserCategory env syntaxcat s with
+    | .error msg => throw msg
+    | .ok syn => ntparser syn
+
+private def mkNonTerminalParser (syntaxcat : Name)
+    (ntparser : Syntax → EIO ParseError ParseOutput)
+    (env : Environment) (s : String) : EIO ParseError ParseOutput :=
+  let parseFun := mkParseFun syntaxcat ntparser
+  parseFun s env
+
+-- TODO: do we need this copy of the environment, or can I remove it from one of the two?
+def regionParser : @ParseFun (MLIR.AST.Region 0) :=
+  fun env : Lean.Environment => mkNonTerminalParser `mlir_region (elabRegion env) env
+
+private def parseFile (env: Lean.Environment)
+    (parser: @ParseFun ParseOutput)
+    (filepath: System.FilePath) : IO (Option ParseOutput) := do
+  let lines ← IO.FS.lines filepath
+  let fileStr := "\n".intercalate lines.toList
+  let parsed ← EIO.toIO' <| parser env fileStr
+  match parsed with
+  | .ok parseOutput => return parseOutput
+  | .error msg => IO.println s!"Error parsing {filepath}:\n{msg}"; return none
+
+private def isFile (p: System.FilePath) : IO Bool := do
+  return (← p.metadata).type == IO.FS.FileType.file
+
+def runParser (parser : @ParseFun ParseOutput) (fileName : String) : IO (Option ParseOutput) := do
+  /- We expect our parser to run with `lake exec`, which sets `LEAN_PATH` to be a colon separated
+    list of package paths.
+    We parse the package paths and set the search path accordingly.
+    For more, see `lake env help.` -/
+  let packagePaths : List String :=
+    match (← IO.getEnv "LEAN_PATH") with
+    | .none => []
+    | .some colonSeparatedPaths => colonSeparatedPaths.splitOn ":"
+  if packagePaths.isEmpty then
+    throw <| IO.userError "Expected `LEAN_PATH` environment variable to be set. Are you running via `lake exec opt`?"
+  initSearchPath (← Lean.findSysroot) packagePaths
+  let modules : Array Import := #[⟨`SSA.Core.MLIRSyntax.EDSL, false⟩]
+  let env ← importModules modules {}
+  let filePath := System.mkFilePath [fileName]
+  if !(← isFile filePath) then
+    throw <| IO.userError s!"File {fileName} does not exist"
+  parseFile env parser filePath
+
+def parseRegionFromFile (fileName : String)
+    (regionParseFun : MLIR.AST.Region 0 → Except ParseError α) : IO (Option α)  := do
+  let ast ← runParser regionParser fileName
+  match Option.map regionParseFun ast with
+  | .some (.ok res) => return res
+  | .some (.error msg) => throw <| IO.userError s!"Error parsing {fileName}:\n{msg}"; return none
+  | .none => return none

--- a/SSA/Projects/InstCombine/LLVM/Opt.lean
+++ b/SSA/Projects/InstCombine/LLVM/Opt.lean
@@ -1,0 +1,22 @@
+import SSA.Projects.InstCombine.LLVM.Parser
+import Cli
+
+def runMainCmd (args : Cli.Parsed) : IO UInt32 := do
+  let fileName := args.positionalArg! "file" |>.as! String
+  let icom? ← parseComFromFile fileName
+  match icom? with
+    | none => return 1
+    | some (Sigma.mk _Γ icom) => do
+      IO.println s!"OK: parsed"
+      IO.println s!"{repr icom}"
+      return 0
+
+def mainCmd := `[Cli|
+    opt VIA runMainCmd;
+    "opt: apply verified rewrites"
+    ARGS:
+      file: String; "Input filename"
+    ]
+
+def main (args : List String): IO UInt32 :=
+  mainCmd.validate args

--- a/SSA/Projects/InstCombine/LLVM/Parser.lean
+++ b/SSA/Projects/InstCombine/LLVM/Parser.lean
@@ -1,0 +1,15 @@
+import SSA.Core.MLIRSyntax.Parser
+import SSA.Projects.InstCombine.LLVM.EDSL
+import Init.Data.Repr
+
+open MLIR AST InstCombine
+def regionTransform (region : Region 0) : Except ParseError
+  (Σ (Γ' : Context) (eff : EffectKind) (ty : Ty), Com LLVM Γ' eff ty) :=
+    let res := mkCom (d:= LLVM) region
+    match res with
+      | Except.error e => Except.error s!"Error:\n{reprStr e}"
+      | Except.ok res => Except.ok res
+
+def parseComFromFile (fileName : String) :
+ IO (Option (Σ (Γ' : Context) (eff : EffectKind) (ty : InstCombine.Ty), Com LLVM Γ' eff ty)) := do
+ parseRegionFromFile fileName regionTransform

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -12,6 +12,13 @@ lean_exe mlirnatural {
   root := `SSA.MLIRNatural
 }
 
+
+lean_exe opt {
+  root := `SSA.Projects.InstCombine.LLVM.Opt
+  -- `supportInterpreter` flag needed to link executable with the Lean frontend
+  supportInterpreter := true
+}
+
 lean_exe ssaLLVMEnumerator {
   root := `SSA.Projects.InstCombine.LLVM.Enumerator
 }

--- a/test/LLVMDialect/InstCombine/bb0.mlir
+++ b/test/LLVMDialect/InstCombine/bb0.mlir
@@ -1,0 +1,9 @@
+{
+  ^bb0(%arg0: i32):
+    %0 = "llvm.mlir.constant"() {value = 8 : i32} : () -> i32
+    %1 = "llvm.mlir.constant"() {value = 31 : i32} : () -> i32
+    %2 = "llvm.ashr"(%arg0, %1) : (i32, i32) -> i32
+    %3 = "llvm.and"(%2, %0) : (i32, i32) -> i32
+    %4 = "llvm.add"(%3, %2) : (i32, i32) -> i32
+    "llvm.return"(%4) : (i32) -> ()
+}


### PR DESCRIPTION
This adds an entry point to parse MLIR code and execute it via our denotational semantics.