### PR TITLE
core: make AliveStatements.lean robust against multiple goals

### DIFF
--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -20,7 +20,7 @@ theorem bitvec_AddSub_1043 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1152 :
     ∀ (e e_1 : LLVM.IntW 1), LLVM.add e_1 e ⊑ LLVM.xor e_1 e := by
@@ -28,7 +28,7 @@ theorem bitvec_AddSub_1152 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1156 :
     ∀ (e : LLVM.IntW w), LLVM.add e e ⊑ LLVM.shl e (LLVM.const? ↑1) := by
@@ -36,7 +36,7 @@ theorem bitvec_AddSub_1156 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1164 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.sub (LLVM.const? 0) e_1) e ⊑ LLVM.sub e e_1 := by
@@ -44,7 +44,7 @@ theorem bitvec_AddSub_1164 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1165 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -53,7 +53,7 @@ theorem bitvec_AddSub_1165 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1176 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add e_1 (LLVM.sub (LLVM.const? 0) e) ⊑ LLVM.sub e_1 e := by
@@ -61,7 +61,7 @@ theorem bitvec_AddSub_1176 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1202 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -70,7 +70,7 @@ theorem bitvec_AddSub_1202 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1295 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
@@ -78,7 +78,7 @@ theorem bitvec_AddSub_1295 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1309 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ LLVM.add e_1 e := by
@@ -86,7 +86,7 @@ theorem bitvec_AddSub_1309 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1539 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub e_1 (LLVM.sub (LLVM.const? 0) e) ⊑ LLVM.add e_1 e := by
@@ -94,7 +94,7 @@ theorem bitvec_AddSub_1539 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1539_2 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub e_1 e ⊑ LLVM.add e_1 (LLVM.neg e) := by
@@ -102,7 +102,7 @@ theorem bitvec_AddSub_1539_2 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1556 :
     ∀ (e e_1 : LLVM.IntW 1), LLVM.sub e_1 e ⊑ LLVM.xor e_1 e := by
@@ -110,7 +110,7 @@ theorem bitvec_AddSub_1556 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1560 :
     ∀ (e : LLVM.IntW w), LLVM.sub (LLVM.const? (Int.negSucc 0)) e ⊑ LLVM.xor e (LLVM.const? (Int.negSucc 0)) := by
@@ -118,7 +118,7 @@ theorem bitvec_AddSub_1560 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1564 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -127,7 +127,7 @@ theorem bitvec_AddSub_1564 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1574 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.sub e_2 (LLVM.add e_1 e) ⊑ LLVM.sub (LLVM.sub e_2 e) e_1 := by
@@ -135,7 +135,7 @@ theorem bitvec_AddSub_1574 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1614 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub e_1 (LLVM.add e_1 e) ⊑ LLVM.sub (LLVM.const? 0) e := by
@@ -143,7 +143,7 @@ theorem bitvec_AddSub_1614 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1619 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub (LLVM.sub e_1 e) e_1 ⊑ LLVM.sub (LLVM.const? 0) e := by
@@ -151,7 +151,7 @@ theorem bitvec_AddSub_1619 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AddSub_1624 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub (LLVM.or e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.and e_1 e := by
@@ -159,7 +159,7 @@ theorem bitvec_AddSub_1624 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_135 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.and (LLVM.xor e_2 e_1) e ⊑ LLVM.xor (LLVM.and e_2 e) (LLVM.and e_1 e) := by
@@ -167,7 +167,7 @@ theorem bitvec_AndOrXor_135 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_144 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.and (LLVM.or e_2 e_1) e ⊑ LLVM.and (LLVM.or e_2 (LLVM.and e_1 e)) e := by
@@ -175,7 +175,7 @@ theorem bitvec_AndOrXor_144 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_698 :
     ∀ (e e_1 e_2 : LLVM.IntW w),
@@ -186,7 +186,7 @@ theorem bitvec_AndOrXor_698 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_709 :
     ∀ (e e_1 e_2 : LLVM.IntW w),
@@ -196,7 +196,7 @@ theorem bitvec_AndOrXor_709 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_716 :
     ∀ (e e_1 e_2 : LLVM.IntW w),
@@ -207,7 +207,7 @@ theorem bitvec_AndOrXor_716 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_794 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -217,7 +217,7 @@ theorem bitvec_AndOrXor_794 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_827 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -227,7 +227,7 @@ theorem bitvec_AndOrXor_827 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_887_2 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -236,7 +236,7 @@ theorem bitvec_AndOrXor_887_2 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1230__A__B___A__B :
     ∀ (e e_1 : LLVM.IntW w),
@@ -246,7 +246,7 @@ theorem bitvec_AndOrXor_1230__A__B___A__B :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1241_AB__AB__AB :
     ∀ (e e_1 : LLVM.IntW w),
@@ -255,7 +255,7 @@ theorem bitvec_AndOrXor_1241_AB__AB__AB :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1247_AB__AB__AB :
     ∀ (e e_1 : LLVM.IntW w),
@@ -264,7 +264,7 @@ theorem bitvec_AndOrXor_1247_AB__AB__AB :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1253_A__AB___A__B :
     ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.xor e_1 e) e_1 ⊑ LLVM.and e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
@@ -272,7 +272,7 @@ theorem bitvec_AndOrXor_1253_A__AB___A__B :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1280_ABA___AB :
     ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.or (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) e_1 ⊑ LLVM.and e_1 e := by
@@ -280,7 +280,7 @@ theorem bitvec_AndOrXor_1280_ABA___AB :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1288_A__B__B__C__A___A__B__C :
     ∀ (e e_1 e_2 : LLVM.IntW w),
@@ -290,7 +290,7 @@ theorem bitvec_AndOrXor_1288_A__B__B__C__A___A__B__C :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1294_A__B__A__B___A__B :
     ∀ (e e_1 : LLVM.IntW w),
@@ -299,7 +299,7 @@ theorem bitvec_AndOrXor_1294_A__B__A__B___A__B :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1683_1 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -309,7 +309,7 @@ theorem bitvec_AndOrXor_1683_1 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1683_2 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -318,7 +318,7 @@ theorem bitvec_AndOrXor_1683_2 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1704 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -328,7 +328,7 @@ theorem bitvec_AndOrXor_1704 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1705 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -338,7 +338,7 @@ theorem bitvec_AndOrXor_1705 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_1733 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -348,7 +348,7 @@ theorem bitvec_AndOrXor_1733 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.or (LLVM.xor e_2 e_1) e ⊑ LLVM.xor (LLVM.or e_2 e) (LLVM.and e_1 (LLVM.not e)) := by
@@ -356,7 +356,7 @@ theorem bitvec_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2113___A__B__A___A__B :
     ∀ (e e_1 : LLVM.IntW w), LLVM.or (LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) e_1 ⊑ LLVM.or e_1 e := by
@@ -364,7 +364,7 @@ theorem bitvec_AndOrXor_2113___A__B__A___A__B :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2118___A__B__A___A__B :
     ∀ (e e_1 : LLVM.IntW w),
@@ -374,7 +374,7 @@ theorem bitvec_AndOrXor_2118___A__B__A___A__B :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2123___A__B__A__B___A__B :
     ∀ (e e_1 : LLVM.IntW w),
@@ -383,7 +383,7 @@ theorem bitvec_AndOrXor_2123___A__B__A__B___A__B :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2188 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -394,7 +394,7 @@ theorem bitvec_AndOrXor_2188 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2231__A__B__B__C__A___A__B__C :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.or (LLVM.xor e_2 e_1) (LLVM.xor (LLVM.xor e_1 e) e_2) ⊑ LLVM.or (LLVM.xor e_2 e_1) e := by
@@ -402,7 +402,7 @@ theorem bitvec_AndOrXor_2231__A__B__B__C__A___A__B__C :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2243__B__C__A__B___B__A__C :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.or (LLVM.and (LLVM.or e_2 e_1) e) e_2 ⊑ LLVM.or e_2 (LLVM.and e e_1) := by
@@ -410,7 +410,7 @@ theorem bitvec_AndOrXor_2243__B__C__A__B___B__A__C :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2247__A__B__A__B :
     ∀ (e e_1 : LLVM.IntW w),
@@ -420,7 +420,7 @@ theorem bitvec_AndOrXor_2247__A__B__A__B :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2263 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.or e_1 (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
@@ -428,7 +428,7 @@ theorem bitvec_AndOrXor_2263 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2264 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -438,7 +438,7 @@ theorem bitvec_AndOrXor_2264 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2265 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.or (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
@@ -446,7 +446,7 @@ theorem bitvec_AndOrXor_2265 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2284 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -456,7 +456,7 @@ theorem bitvec_AndOrXor_2284 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2285 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -466,7 +466,7 @@ theorem bitvec_AndOrXor_2285 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2297 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -476,7 +476,7 @@ theorem bitvec_AndOrXor_2297 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2367 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.or (LLVM.or e_2 e_1) e ⊑ LLVM.or (LLVM.or e_2 e) e_1 := by
@@ -484,7 +484,7 @@ theorem bitvec_AndOrXor_2367 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2416 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -494,7 +494,7 @@ theorem bitvec_AndOrXor_2416 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2417 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -504,7 +504,7 @@ theorem bitvec_AndOrXor_2417 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2429 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -514,7 +514,7 @@ theorem bitvec_AndOrXor_2429 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2430 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -524,7 +524,7 @@ theorem bitvec_AndOrXor_2430 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2443 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -533,7 +533,7 @@ theorem bitvec_AndOrXor_2443 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2453 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -542,7 +542,7 @@ theorem bitvec_AndOrXor_2453 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2475 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -551,7 +551,7 @@ theorem bitvec_AndOrXor_2475 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2486 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -560,7 +560,7 @@ theorem bitvec_AndOrXor_2486 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2581__BAB___A__B :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.or e_1 e) e ⊑ LLVM.and e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
@@ -568,7 +568,7 @@ theorem bitvec_AndOrXor_2581__BAB___A__B :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2587__BAA___B__A :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.and e_1 e) e ⊑ LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e := by
@@ -576,7 +576,7 @@ theorem bitvec_AndOrXor_2587__BAA___B__A :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2595 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by
@@ -584,7 +584,7 @@ theorem bitvec_AndOrXor_2595 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2607 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -595,7 +595,7 @@ theorem bitvec_AndOrXor_2607 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2617 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -606,7 +606,7 @@ theorem bitvec_AndOrXor_2617 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2647 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
@@ -614,7 +614,7 @@ theorem bitvec_AndOrXor_2647 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2658 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -624,7 +624,7 @@ theorem bitvec_AndOrXor_2658 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_AndOrXor_2663 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -634,7 +634,7 @@ theorem bitvec_AndOrXor_2663 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_152 :
     ∀ (e : LLVM.IntW w), LLVM.mul e (LLVM.const? (Int.negSucc 0)) ⊑ LLVM.sub (LLVM.const? 0) e := by
@@ -642,7 +642,7 @@ theorem bitvec_152 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_229 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.mul (LLVM.add e_2 e_1) e ⊑ LLVM.add (LLVM.mul e_2 e) (LLVM.mul e_1 e) := by
@@ -650,7 +650,7 @@ theorem bitvec_229 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_239 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.mul (LLVM.sub (LLVM.const? 0) e_1) (LLVM.sub (LLVM.const? 0) e) ⊑ LLVM.mul e_1 e := by
@@ -658,7 +658,7 @@ theorem bitvec_239 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_275 :
     ∀ (e e_1 : LLVM.IntW 5), LLVM.mul (LLVM.udiv e_1 e) e ⊑ LLVM.sub e_1 (LLVM.urem e_1 e) := by
@@ -666,7 +666,7 @@ theorem bitvec_275 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_275_2 :
     ∀ (e e_1 : LLVM.IntW 5), LLVM.mul (LLVM.sdiv e_1 e) e ⊑ LLVM.sub e_1 (LLVM.srem e_1 e) := by
@@ -674,7 +674,7 @@ theorem bitvec_275_2 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_276 :
     ∀ (e e_1 : LLVM.IntW 5), LLVM.mul (LLVM.sdiv e_1 e) (LLVM.sub (LLVM.const? 0) e) ⊑ LLVM.sub (LLVM.srem e_1 e) e_1 := by
@@ -682,7 +682,7 @@ theorem bitvec_276 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_276_2 :
     ∀ (e e_1 : LLVM.IntW 5), LLVM.mul (LLVM.udiv e_1 e) (LLVM.sub (LLVM.const? 0) e) ⊑ LLVM.sub (LLVM.urem e_1 e) e_1 := by
@@ -690,7 +690,7 @@ theorem bitvec_276_2 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_283 :
     ∀ (e e_1 : LLVM.IntW 1), LLVM.mul e_1 e ⊑ LLVM.and e_1 e := by
@@ -698,7 +698,7 @@ theorem bitvec_283 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_290__292 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.mul (LLVM.shl (LLVM.const? ↑1) e_1) e ⊑ LLVM.shl e e_1 := by
@@ -706,7 +706,7 @@ theorem bitvec_290__292 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_820 :
     ∀ (e e_1 : LLVM.IntW 9), LLVM.sdiv (LLVM.sub e_1 (LLVM.srem e_1 e)) e ⊑ LLVM.sdiv e_1 e := by
@@ -714,7 +714,7 @@ theorem bitvec_820 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_820' :
     ∀ (e e_1 : LLVM.IntW 9), LLVM.udiv (LLVM.sub e_1 (LLVM.urem e_1 e)) e ⊑ LLVM.udiv e_1 e := by
@@ -722,7 +722,7 @@ theorem bitvec_820' :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_1030 :
     ∀ (e : LLVM.IntW w), LLVM.sdiv e (LLVM.const? (Int.negSucc 0)) ⊑ LLVM.sub (LLVM.const? 0) e := by
@@ -730,7 +730,7 @@ theorem bitvec_1030 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_select_1100 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.select (LLVM.const? ↑1) e_1 e ⊑ e_1 := by
@@ -738,7 +738,7 @@ theorem bitvec_select_1100 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_Select_1105 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.select (LLVM.const? 0) e_1 e ⊑ e := by
@@ -746,7 +746,7 @@ theorem bitvec_Select_1105 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_InstCombineShift__239 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.lshr (LLVM.shl e_1 e) e ⊑ LLVM.and e_1 (LLVM.lshr (LLVM.const? (Int.negSucc 0)) e) := by
@@ -754,7 +754,7 @@ theorem bitvec_InstCombineShift__239 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_InstCombineShift__279 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.shl (LLVM.lshr e_1 e) e ⊑ LLVM.and e_1 (LLVM.shl (LLVM.const? (Int.negSucc 0)) e) := by
@@ -762,7 +762,7 @@ theorem bitvec_InstCombineShift__279 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_InstCombineShift__440 :
     ∀ (e e_1 e_2 e_3 : LLVM.IntW w),
@@ -772,7 +772,7 @@ theorem bitvec_InstCombineShift__440 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_InstCombineShift__476 :
     ∀ (e e_1 e_2 e_3 : LLVM.IntW w),
@@ -782,7 +782,7 @@ theorem bitvec_InstCombineShift__476 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_InstCombineShift__497 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.lshr (LLVM.xor e_2 e_1) e ⊑ LLVM.xor (LLVM.lshr e_2 e) (LLVM.lshr e_1 e) := by
@@ -790,7 +790,7 @@ theorem bitvec_InstCombineShift__497 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_InstCombineShift__497''' :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.shl (LLVM.add e_2 e_1) e ⊑ LLVM.add (LLVM.shl e_2 e) (LLVM.shl e_1 e) := by
@@ -798,7 +798,7 @@ theorem bitvec_InstCombineShift__497''' :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry
 
 theorem bitvec_InstCombineShift__582 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.lshr (LLVM.shl e_1 e) e ⊑ LLVM.and e_1 (LLVM.lshr (LLVM.const? (Int.negSucc 0)) e) := by
@@ -806,4 +806,4 @@ theorem bitvec_InstCombineShift__582 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  try sorry
+  all_goals sorry

--- a/SSA/Projects/InstCombine/update_alive_statements.py
+++ b/SSA/Projects/InstCombine/update_alive_statements.py
@@ -85,7 +85,7 @@ def getStatement(preamble: List[str], id : int, proof: List[str]) -> str:
 
     stmt = name
     stmt += msg
-    stmt += " := by\n  simp_alive_undef\n  simp_alive_ops\n  simp_alive_case_bash\n  try alive_auto\n  try sorry"
+    stmt += " := by\n  simp_alive_undef\n  simp_alive_ops\n  simp_alive_case_bash\n  try alive_auto\n  all_goals sorry"
 
     print(stmt)
 


### PR DESCRIPTION
https://github.com/opencompl/ssa/pull/225 will fix three statements, one of which will introduce multiple goals in `AliveStatements.lean`. This PR makes `AliveStatements.lean` robust against multiple worries by using `all_goals`.

Thank you @alexkeizer for proposing this.