### PR TITLE
feat: make LLVM eDSL work without reduce - one instruction case

### DIFF
--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -141,7 +141,7 @@ def castCtxt {Γ : Ctxt Op} (h_eq : Γ = Δ) : Γ.Var ty → Δ.Var ty
     (v.castCtxt h₁).castCtxt h₂ = v.castCtxt (by simp [*]) := by subst h₁ h₂; simp
 
 @[simp]
-theorem toMap_last {Γ : Ctxt Ty2} {t : Ty2} : (Ctxt.Var.last Γ t).toMap = Ctxt.Var.last (Γ.map f) (f t) := rfl
+theorem toMap_last {Γ : Ctxt Ty} {t : Ty} : (Ctxt.Var.last Γ t).toMap = Ctxt.Var.last (Γ.map f) (f t) := rfl
 
 /-- This is an induction principle that case splits on whether or not a variable
 is the last variable in a context. -/

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -140,6 +140,9 @@ def castCtxt {Γ : Ctxt Op} (h_eq : Γ = Δ) : Γ.Var ty → Δ.Var ty
 @[simp] lemma castCtxt_castCtxt (v : Var Γ t) (h₁ : Γ = Δ) (h₂ : Δ = Ξ) :
     (v.castCtxt h₁).castCtxt h₂ = v.castCtxt (by simp [*]) := by subst h₁ h₂; simp
 
+@[simp]
+theorem toMap_last {Γ : Ctxt Ty2} {t : Ty2} : (Ctxt.Var.last Γ t).toMap = Ctxt.Var.last (Γ.map f) (f t) := rfl
+
 /-- This is an induction principle that case splits on whether or not a variable
 is the last variable in a context. -/
 @[elab_as_elim, cases_eliminator]

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1327,12 +1327,6 @@ theorem DialectMorphism.preserves_effectKind (op : d.Op) :
     DialectSignature.effectKind (f.mapOp op) = DialectSignature.effectKind op := by
   simp only [DialectSignature.effectKind, Function.comp_apply, f.preserves_signature]; rfl
 
-@[simp] lemma DialectMorphism.mapOp_mk (fOp : d.Op → d'.Op) (fTy) (h) :
-    mapOp ⟨fOp, fTy, h⟩ = fOp := rfl
-
-@[simp] lemma DialectMorphism.mapTy_mk (fOp : d.Op → d'.Op) (fTy) (h) :
-    mapTy ⟨fOp, fTy, h⟩ = fTy := rfl
-
 mutual
 
 -- TODO: `map` is ambiguous, rename it to `changeDialect` (to mirror `changeVars`)
@@ -1365,14 +1359,6 @@ def Lets.changeDialect : Lets d Γ_in eff Γ_out → Lets d' (f.mapTy <$> Γ_in)
 
 section Lemmas
 
-/-!
-There seems to be a bug with the `rfl` suggestion. When it fails, tt says:
-```
-Try using the reflexivitiy lemma for your relation explicitly, e.g. `exact Eq.rfl`.
-```
-But `Eq.rfl` does not exist, it should be `exact Eq.refl _`
--/
-
 @[simp] lemma Com.changeDialect_ret (f : DialectMorphism d d') (v : Var Γ t):
     Com.changeDialect f (Com.ret v : Com d Γ eff t) = Com.ret v.toMap := by
   cases eff <;> rfl
@@ -1382,19 +1368,6 @@ But `Eq.rfl` does not exist, it should be `exact Eq.refl _`
     Com.changeDialect f (Com.lete e body)
       = Com.lete (e.changeDialect f) (body.changeDialect f) := by
   simp only [List.map_eq_map, changeDialect]
-
-@[simp] lemma Expr.changeDialect_mk (f : DialectMorphism d d') (op ty_eq eff_le args regArgs) :
-    Expr.changeDialect f (⟨op, ty_eq, eff_le, args, regArgs⟩ : Expr d Γ eff t)
-      = ⟨f.mapOp op,
-          ty_eq ▸ (f.preserves_outTy _).symm,
-          f.preserves_effectKind _ ▸ eff_le,
-          f.preserves_sig _ ▸ args.map' f.mapTy fun _ => Var.toMap (f:=f.mapTy),
-          f.preserves_regSig _ ▸
-            HVector.changeDialect f regArgs⟩ := by
-  subst ty_eq; simp [Expr.changeDialect]
-
-@[simp] lemma HVector.changeDialect_nil (f : DialectMorphism d d') :
-    HVector.changeDialect (eff := eff) f nil = nil := rfl
 
 end Lemmas
 

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1365,8 +1365,7 @@ section Lemmas
 
 @[simp] lemma Com.changeDialect_lete (f : DialectMorphism d d')
     (e : Expr d Γ eff t) (body : Com d _ eff u) :
-    Com.changeDialect f (Com.lete e body)
-      = Com.lete (e.changeDialect f) (body.changeDialect f) := by
+    (Com.lete e body).changeDialect f = Com.lete (e.changeDialect f) (body.changeDialect f) := by
   simp only [List.map_eq_map, changeDialect]
 
 end Lemmas

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1359,7 +1359,7 @@ def Lets.changeDialect : Lets d Γ_in eff Γ_out → Lets d' (f.mapTy <$> Γ_in)
 
 section Lemmas
 
-@[simp] lemma Com.changeDialect_ret (f : DialectMorphism d d') (v : Var Γ t):
+@[simp] lemma Com.changeDialect_ret (f : DialectMorphism d d') (v : Var Γ t) :
     Com.changeDialect f (Com.ret v : Com d Γ eff t) = Com.ret v.toMap := by
   cases eff <;> rfl
 

--- a/SSA/Projects/InstCombine/Tactic.lean
+++ b/SSA/Projects/InstCombine/Tactic.lean
@@ -20,10 +20,12 @@ and all `Width.mvar` should be resolved into `Width.concrete`.  -/
 macro "simp_alive_meta" : tactic =>
  `(tactic|
      (
+      simp (config := {failIfUnchanged := false }) only [Com.changeDialect_ret, Com.changeDialect_lete, Expr.changeDialect]
       dsimp (config := {failIfUnchanged := false }) only [Functor.map]
-      dsimp (config := {failIfUnchanged := false }) only [Ctxt.DerivedCtxt.snoc_ctxt_eq_ctxt_snoc]
       dsimp (config := {failIfUnchanged := false }) only [Ctxt.Var.succ_eq_toSnoc]
       dsimp (config := {failIfUnchanged := false }) only [Ctxt.Var.zero_eq_last]
+      dsimp (config := {failIfUnchanged := false }) only [Ctxt.Var.toMap_last]
+      dsimp (config := {failIfUnchanged := false }) only [Ctxt.DerivedCtxt.snoc_ctxt_eq_ctxt_snoc]
       dsimp (config := {failIfUnchanged := false }) only [List.map]
       dsimp (config := {failIfUnchanged := false }) only [Width.mvar]
       dsimp (config := {failIfUnchanged := false }) only [Ctxt.map_snoc, Ctxt.map_nil]

--- a/SSA/Projects/InstCombine/Tactic.lean
+++ b/SSA/Projects/InstCombine/Tactic.lean
@@ -22,8 +22,8 @@ macro "simp_alive_meta" : tactic =>
      (
       dsimp (config := {failIfUnchanged := false }) only [Functor.map]
       dsimp (config := {failIfUnchanged := false }) only [Ctxt.DerivedCtxt.snoc_ctxt_eq_ctxt_snoc]
-      dsimp (config := {failIfUnchanged := false }) only [Var.succ_eq_toSnoc]
-      dsimp (config := {failIfUnchanged := false }) only [Var.zero_eq_last]
+      dsimp (config := {failIfUnchanged := false }) only [Ctxt.Var.succ_eq_toSnoc]
+      dsimp (config := {failIfUnchanged := false }) only [Ctxt.Var.zero_eq_last]
       dsimp (config := {failIfUnchanged := false }) only [List.map]
       dsimp (config := {failIfUnchanged := false }) only [Width.mvar]
       dsimp (config := {failIfUnchanged := false }) only [Ctxt.map_snoc, Ctxt.map_nil]

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -277,6 +277,25 @@ def one_inst_macro_proof (w : Nat) :
   simp_alive_ssa
   apply one_inst_stmt
 
+def aa : (instantiateMOp ⟨[w], one_inst_macro_noreduce.proof_1 w⟩ (MOp.unary (Width.mvar (0 : Fin (0 + 1))) MOp.UnaryOp.not)) =
+  (Op.unary w MOp.UnaryOp.not) := rfl
+
+def castA :
+(@Ctxt.Var.toMap (MTy 1) [MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)]
+  (MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)) Ty
+  (instantiateMTy ⟨[w], one_inst_macro_noreduce.proof_1 w⟩)
+  (Ctxt.Var.last ∅ (MTy.bitvec (ConcreteOrMVar.mvar ⟨0, _⟩))) : (Ctxt.map (instantiateMTy ⟨[w], one_inst_macro_noreduce.proof_1 w⟩)
+      [MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)]).Var
+  (instantiateMTy ⟨[w], one_inst_macro_noreduce.proof_1 w⟩
+    (MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)))) =
+                (Ctxt.Var.last [] (Ty.bitvec w)) := rfl
+
+def srf : (@Ctxt.Var.toMap (MTy 1) [MTy.bitvec (ConcreteOrMVar.mvar 0), MTy.bitvec (ConcreteOrMVar.mvar 0)]
+  _ Ty (instantiateMTy ⟨[w], one_inst_macro_noreduce.proof_1 w⟩)
+  (Ctxt.Var.last (MTy.bitvec (ConcreteOrMVar.mvar 0) :: ∅) (MTy.bitvec (ConcreteOrMVar.mvar 0))))
+  = Ctxt.Var.last [Ty.bitvec w] (Ty.bitvec w) := rfl
+
+
 set_option pp.proofs true in
 def one_inst_macro_proof_noreduce (w : Nat) :
   one_inst_macro_noreduce w ⊑ one_inst_macro_noreduce w := by
@@ -284,13 +303,14 @@ def one_inst_macro_proof_noreduce (w : Nat) :
   simp only [Com.changeDialect_ret, Com.changeDialect_lete]
   simp only [Com.changeDialect_ret, Com.changeDialect_lete, Expr.changeDialect,
     (HVector.changeDialect_nil), InstcombineTransformDialect.MOp.instantiateCom]
-  dsimp! []
   dsimp only [DialectMorphism.mapOp_mk, DialectMorphism.mapTy_mk,
     InstcombineTransformDialect.MOp.instantiateCom,
     InstcombineTransformDialect.instantiateMOp,
     InstcombineTransformDialect.instantiateMTy,
     HVector.changeDialect_nil, HVector.map']
   simp_alive_meta
+  dsimp [castA]
+  rw [srf]
   simp_alive_ssa
   apply one_inst_stmt
 

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -290,23 +290,10 @@ def castA :
     (MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)))) =
                 (Ctxt.Var.last [] (Ty.bitvec w)) := rfl
 
-@[simp]
-theorem Ctxt.Var.toMap_last {Γ : Ctxt Ty2} {t : Ty2} : (Ctxt.Var.last Γ t).toMap = Ctxt.Var.last (Γ.map f) (f t) := rfl
-
 set_option pp.proofs true in
 def one_inst_macro_proof_noreduce (w : Nat) :
   one_inst_macro_noreduce w ⊑ one_inst_macro_noreduce w := by
   unfold one_inst_macro_noreduce
-  simp only [Com.changeDialect_ret, Com.changeDialect_lete]
-  simp only [Com.changeDialect_ret, Com.changeDialect_lete, Expr.changeDialect,
-    (HVector.changeDialect_nil), InstcombineTransformDialect.MOp.instantiateCom]
-  dsimp only [DialectMorphism.mapOp_mk, DialectMorphism.mapTy_mk,
-    InstcombineTransformDialect.MOp.instantiateCom,
-    InstcombineTransformDialect.instantiateMOp,
-    InstcombineTransformDialect.instantiateMTy,
-    HVector.changeDialect_nil, HVector.map']
-  simp_alive_meta
-  dsimp (config := {failIfUnchanged := false }) only [Ctxt.Var.toMap_last]
   simp_alive_meta
   simp_alive_ssa
   apply one_inst_stmt

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -277,7 +277,6 @@ def one_inst_macro_proof (w : Nat) :
   simp_alive_ssa
   apply one_inst_stmt
 
-set_option pp.proofs true in
 def one_inst_macro_proof_noreduce (w : Nat) :
   one_inst_macro_noreduce w ⊑ one_inst_macro_noreduce w := by
   unfold one_inst_macro_noreduce

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -277,19 +277,6 @@ def one_inst_macro_proof (w : Nat) :
   simp_alive_ssa
   apply one_inst_stmt
 
-def aa : (instantiateMOp ⟨[w], one_inst_macro_noreduce.proof_1 w⟩ (MOp.unary (Width.mvar (0 : Fin (0 + 1))) MOp.UnaryOp.not)) =
-  (Op.unary w MOp.UnaryOp.not) := rfl
-
-def castA :
-(@Ctxt.Var.toMap (MTy 1) [MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)]
-  (MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)) Ty
-  (instantiateMTy ⟨[w], one_inst_macro_noreduce.proof_1 w⟩)
-  (Ctxt.Var.last ∅ (MTy.bitvec (ConcreteOrMVar.mvar ⟨0, _⟩))) : (Ctxt.map (instantiateMTy ⟨[w], one_inst_macro_noreduce.proof_1 w⟩)
-      [MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)]).Var
-  (instantiateMTy ⟨[w], one_inst_macro_noreduce.proof_1 w⟩
-    (MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)))) =
-                (Ctxt.Var.last [] (Ty.bitvec w)) := rfl
-
 set_option pp.proofs true in
 def one_inst_macro_proof_noreduce (w : Nat) :
   one_inst_macro_noreduce w ⊑ one_inst_macro_noreduce w := by

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -290,11 +290,8 @@ def castA :
     (MTy.bitvec (ConcreteOrMVar.mvar ⟨0, one_inst_macro_noreduce.proof_2⟩)))) =
                 (Ctxt.Var.last [] (Ty.bitvec w)) := rfl
 
-def srf : (@Ctxt.Var.toMap (MTy 1) [MTy.bitvec (ConcreteOrMVar.mvar 0), MTy.bitvec (ConcreteOrMVar.mvar 0)]
-  _ Ty (instantiateMTy ⟨[w], one_inst_macro_noreduce.proof_1 w⟩)
-  (Ctxt.Var.last (MTy.bitvec (ConcreteOrMVar.mvar 0) :: ∅) (MTy.bitvec (ConcreteOrMVar.mvar 0))))
-  = Ctxt.Var.last [Ty.bitvec w] (Ty.bitvec w) := rfl
-
+@[simp]
+theorem Ctxt.Var.toMap_last {Γ : Ctxt Ty2} {t : Ty2} : (Ctxt.Var.last Γ t).toMap = Ctxt.Var.last (Γ.map f) (f t) := rfl
 
 set_option pp.proofs true in
 def one_inst_macro_proof_noreduce (w : Nat) :
@@ -309,8 +306,8 @@ def one_inst_macro_proof_noreduce (w : Nat) :
     InstcombineTransformDialect.instantiateMTy,
     HVector.changeDialect_nil, HVector.map']
   simp_alive_meta
-  dsimp [castA]
-  rw [srf]
+  dsimp (config := {failIfUnchanged := false }) only [Ctxt.Var.toMap_last]
+  simp_alive_meta
   simp_alive_ssa
   apply one_inst_stmt
 

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -246,6 +246,14 @@ def one_inst_macro (w: Nat):=
     "llvm.return" (%0) : (_) -> ()
   }]
 
+set_option ssa.alive_icom_reduce false in
+def one_inst_macro_noreduce (w: Nat):=
+  [alive_icom (w)|{
+  ^bb0(%arg0: _):
+    %0 = "llvm.not" (%arg0) : (_, _) -> (_)
+    "llvm.return" (%0) : (_) -> ()
+  }]
+
 def one_inst_com (w : ℕ) :
   Com InstCombine.LLVM [InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
   Com.lete (not w 0) <|
@@ -265,6 +273,13 @@ def one_inst_com_proof (w : Nat) :
 def one_inst_macro_proof (w : Nat) :
   one_inst_macro w ⊑ one_inst_macro w := by
   unfold one_inst_macro
+  simp_alive_meta
+  simp_alive_ssa
+  apply one_inst_stmt
+
+def one_inst_macro_proof_noreduce (w : Nat) :
+  one_inst_macro_noreduce w ⊑ one_inst_macro_noreduce w := by
+  unfold one_inst_macro_noreduce
   simp_alive_meta
   simp_alive_ssa
   apply one_inst_stmt

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -277,9 +277,19 @@ def one_inst_macro_proof (w : Nat) :
   simp_alive_ssa
   apply one_inst_stmt
 
+set_option pp.proofs true in
 def one_inst_macro_proof_noreduce (w : Nat) :
   one_inst_macro_noreduce w ⊑ one_inst_macro_noreduce w := by
   unfold one_inst_macro_noreduce
+  simp only [Com.changeDialect_ret, Com.changeDialect_lete]
+  simp only [Com.changeDialect_ret, Com.changeDialect_lete, Expr.changeDialect,
+    (HVector.changeDialect_nil), InstcombineTransformDialect.MOp.instantiateCom]
+  dsimp! []
+  dsimp only [DialectMorphism.mapOp_mk, DialectMorphism.mapTy_mk,
+    InstcombineTransformDialect.MOp.instantiateCom,
+    InstcombineTransformDialect.instantiateMOp,
+    InstcombineTransformDialect.instantiateMTy,
+    HVector.changeDialect_nil, HVector.map']
   simp_alive_meta
   simp_alive_ssa
   apply one_inst_stmt


### PR DESCRIPTION
The use of reduce in the meta programming framework has made the frontend pretty fragile. We build now step-by-step the simp lemmas needed to simplify the eDSL away such that reduce can eventually be dropped.

This change is needed to enable the lean 4.9.0 update.

Co-authored-by: Alex Keizer <alex@keizer.dev>
Co-authored-by: Siddharth Bhat <siddu.druid@gmail.com>