### PR TITLE
chore: use full context in simp_alive_meta

### DIFF
--- a/SSA/Projects/InstCombine/Tactic.lean
+++ b/SSA/Projects/InstCombine/Tactic.lean
@@ -12,7 +12,6 @@ import Batteries.Data.BitVec
 import Mathlib.Data.BitVec.Lemmas
 
 open MLIR AST
-open Ctxt
 
 /-- We eliminate our alive framework's metavarible machinery.
 At the end of this pass, all `InstcombineTransformDialect.instantiate*` must be eliminated,
@@ -22,8 +21,8 @@ macro "simp_alive_meta" : tactic =>
      (
       dsimp (config := {failIfUnchanged := false }) only [Functor.map]
       dsimp (config := {failIfUnchanged := false }) only [Ctxt.DerivedCtxt.snoc_ctxt_eq_ctxt_snoc]
-      dsimp (config := {failIfUnchanged := false }) only [Var.succ_eq_toSnoc]
-      dsimp (config := {failIfUnchanged := false }) only [Var.zero_eq_last]
+      dsimp (config := {failIfUnchanged := false }) only [Ctxt.Var.succ_eq_toSnoc]
+      dsimp (config := {failIfUnchanged := false }) only [Ctxt.Var.zero_eq_last]
       dsimp (config := {failIfUnchanged := false }) only [List.map]
       dsimp (config := {failIfUnchanged := false }) only [Width.mvar]
       dsimp (config := {failIfUnchanged := false }) only [Ctxt.map_snoc, Ctxt.map_nil]


### PR DESCRIPTION
This is helpful for debugging, when we copy the individual statements to the actual proof, which may not have Ctxt open.