### PR TITLE
chore: do not make Ctxt.Var.toMap a coercion

### DIFF
--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -121,7 +121,6 @@ theorem succ_eq_toSnoc {Γ : Ctxt Ty} {t : Ty} {w} (h : (Γ.snoc t).get? (w+1) =
   rfl
 
 /-- Transport a variable from `Γ` to any mapped context `Γ.map f` -/
-@[coe]
 def toMap : Var Γ t → Var (Γ.map f) (f t)
   | ⟨i, h⟩ => ⟨i, by
       simp only [get?, map, List.get?_map, Option.map_eq_some']


### PR DESCRIPTION
Before this change toSnoc and toMap could not be distinguished visually, which made debugging unnecessarily hard. Also, we really want to eliminate toMap to ensure that all meta-abstractions are liminated before we try to remove the SSA semantics.