### PR TITLE
chore: disable reduction in LLVM eDSL

### DIFF
--- a/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
@@ -53,6 +53,7 @@ BitVec.toNat (BitVec.ofInt w 0) = 0 := by
 theorem alive_DivRemOfSelect (w : Nat) :
     alive_DivRemOfSelect_src w ⊑ alive_DivRemOfSelect_tgt w := by
   unfold alive_DivRemOfSelect_src alive_DivRemOfSelect_tgt
+  simp_alive_meta
   simp_alive_ssa
   simp_alive_undef
   simp [simp_llvm]

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -40,6 +40,7 @@ def alive_DivRemOfSelect_tgt (w : Nat) :=
 theorem alive_DivRemOfSelect (w : Nat) :
     alive_DivRemOfSelect_src w ⊑ alive_DivRemOfSelect_tgt w := by
   unfold alive_DivRemOfSelect_src alive_DivRemOfSelect_tgt
+  simp_alive_meta
   simp_alive_ssa
   simp_alive_undef
   simp only [simp_llvm]

--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -17,7 +17,7 @@ set_option linter.unreachableTactic false
 
 theorem bitvec_AddSub_1043 :
     ∀ (e e_1 e_2 : LLVM.IntW w),
-      LLVM.add (LLVM.add (LLVM.xor (LLVM.and e_2 e_1) e_1) (LLVM.const? ↑1)) e ⊑ LLVM.sub e (LLVM.or e_2 (LLVM.not e_1)) := by
+      LLVM.add (LLVM.add (LLVM.xor (LLVM.and e_2 e_1) e_1) (LLVM.const? 1)) e ⊑ LLVM.sub e (LLVM.or e_2 (LLVM.not e_1)) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem bitvec_AddSub_1152 :
   all_goals sorry
 
 theorem bitvec_AddSub_1156 :
-    ∀ (e : LLVM.IntW w), LLVM.add e e ⊑ LLVM.shl e (LLVM.const? ↑1) := by
+    ∀ (e : LLVM.IntW w), LLVM.add e e ⊑ LLVM.shl e (LLVM.const? 1) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -66,8 +66,7 @@ theorem bitvec_AddSub_1176 :
   all_goals sorry
 
 theorem bitvec_AddSub_1202 :
-    ∀ (e e_1 : LLVM.IntW w),
-      LLVM.add (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e ⊑ LLVM.sub (LLVM.sub e (LLVM.const? ↑1)) e_1 := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.xor e_1 (LLVM.const? (-1))) e ⊑ LLVM.sub (LLVM.sub e (LLVM.const? 1)) e_1 := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -115,7 +114,7 @@ theorem bitvec_AddSub_1556 :
   all_goals sorry
 
 theorem bitvec_AddSub_1560 :
-    ∀ (e : LLVM.IntW w), LLVM.sub (LLVM.const? (Int.negSucc 0)) e ⊑ LLVM.xor e (LLVM.const? (Int.negSucc 0)) := by
+    ∀ (e : LLVM.IntW w), LLVM.sub (LLVM.const? (-1)) e ⊑ LLVM.xor e (LLVM.const? (-1)) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -123,8 +122,7 @@ theorem bitvec_AddSub_1560 :
   all_goals sorry
 
 theorem bitvec_AddSub_1564 :
-    ∀ (e e_1 : LLVM.IntW w),
-      LLVM.sub e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) ⊑ LLVM.add e (LLVM.add e_1 (LLVM.const? ↑1)) := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.sub e_1 (LLVM.xor e (LLVM.const? (-1))) ⊑ LLVM.add e (LLVM.add e_1 (LLVM.const? 1)) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -242,8 +240,8 @@ theorem bitvec_AndOrXor_887_2 :
 
 theorem bitvec_AndOrXor_1230__A__B___A__B :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) (LLVM.xor e (LLVM.const? (Int.negSucc 0))) ⊑
-        LLVM.xor (LLVM.or e_1 e) (LLVM.const? (Int.negSucc 0)) := by
+      LLVM.and (LLVM.xor e_1 (LLVM.const? (-1))) (LLVM.xor e (LLVM.const? (-1))) ⊑
+        LLVM.xor (LLVM.or e_1 e) (LLVM.const? (-1)) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -251,8 +249,7 @@ theorem bitvec_AndOrXor_1230__A__B___A__B :
   all_goals sorry
 
 theorem bitvec_AndOrXor_1241_AB__AB__AB :
-    ∀ (e e_1 : LLVM.IntW w),
-      LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.and e_1 e) (LLVM.const? (Int.negSucc 0))) ⊑ LLVM.xor e_1 e := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.and e_1 e) (LLVM.const? (-1))) ⊑ LLVM.xor e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -260,8 +257,7 @@ theorem bitvec_AndOrXor_1241_AB__AB__AB :
   all_goals sorry
 
 theorem bitvec_AndOrXor_1247_AB__AB__AB :
-    ∀ (e e_1 : LLVM.IntW w),
-      LLVM.and (LLVM.xor (LLVM.and e_1 e) (LLVM.const? (Int.negSucc 0))) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.xor (LLVM.and e_1 e) (LLVM.const? (-1))) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -269,7 +265,7 @@ theorem bitvec_AndOrXor_1247_AB__AB__AB :
   all_goals sorry
 
 theorem bitvec_AndOrXor_1253_A__AB___A__B :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.xor e_1 e) e_1 ⊑ LLVM.and e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.xor e_1 e) e_1 ⊑ LLVM.and e_1 (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -277,7 +273,7 @@ theorem bitvec_AndOrXor_1253_A__AB___A__B :
   all_goals sorry
 
 theorem bitvec_AndOrXor_1280_ABA___AB :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.or (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) e_1 ⊑ LLVM.and e_1 e := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.or (LLVM.xor e_1 (LLVM.const? (-1))) e) e_1 ⊑ LLVM.and e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -287,7 +283,7 @@ theorem bitvec_AndOrXor_1280_ABA___AB :
 theorem bitvec_AndOrXor_1288_A__B__B__C__A___A__B__C :
     ∀ (e e_1 e_2 : LLVM.IntW w),
       LLVM.and (LLVM.xor e_2 e_1) (LLVM.xor (LLVM.xor e_1 e) e_2) ⊑
-        LLVM.and (LLVM.xor e_2 e_1) (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+        LLVM.and (LLVM.xor e_2 e_1) (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -295,8 +291,7 @@ theorem bitvec_AndOrXor_1288_A__B__B__C__A___A__B__C :
   all_goals sorry
 
 theorem bitvec_AndOrXor_1294_A__B__A__B___A__B :
-    ∀ (e e_1 : LLVM.IntW w),
-      LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) ⊑ LLVM.and e_1 e := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.xor e_1 (LLVM.const? (-1))) e) ⊑ LLVM.and e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -315,7 +310,7 @@ theorem bitvec_AndOrXor_1683_1 :
 
 theorem bitvec_AndOrXor_1683_2 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.or (LLVM.icmp LLVM.IntPredicate.uge e_1 e) (LLVM.icmp LLVM.IntPredicate.ne e_1 e) ⊑ LLVM.const? ↑1 := by
+      LLVM.or (LLVM.icmp LLVM.IntPredicate.uge e_1 e) (LLVM.icmp LLVM.IntPredicate.ne e_1 e) ⊑ LLVM.const? 1 := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -325,7 +320,7 @@ theorem bitvec_AndOrXor_1683_2 :
 theorem bitvec_AndOrXor_1704 :
     ∀ (e e_1 : LLVM.IntW w),
       LLVM.or (LLVM.icmp LLVM.IntPredicate.eq e_1 (LLVM.const? 0)) (LLVM.icmp LLVM.IntPredicate.ult e e_1) ⊑
-        LLVM.icmp LLVM.IntPredicate.uge (LLVM.add e_1 (LLVM.const? (Int.negSucc 0))) e := by
+        LLVM.icmp LLVM.IntPredicate.uge (LLVM.add e_1 (LLVM.const? (-1))) e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -335,7 +330,7 @@ theorem bitvec_AndOrXor_1704 :
 theorem bitvec_AndOrXor_1705 :
     ∀ (e e_1 : LLVM.IntW w),
       LLVM.or (LLVM.icmp LLVM.IntPredicate.eq e_1 (LLVM.const? 0)) (LLVM.icmp LLVM.IntPredicate.ugt e_1 e) ⊑
-        LLVM.icmp LLVM.IntPredicate.uge (LLVM.add e_1 (LLVM.const? (Int.negSucc 0))) e := by
+        LLVM.icmp LLVM.IntPredicate.uge (LLVM.add e_1 (LLVM.const? (-1))) e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -361,7 +356,7 @@ theorem bitvec_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
   all_goals sorry
 
 theorem bitvec_AndOrXor_2113___A__B__A___A__B :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.or (LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) e_1 ⊑ LLVM.or e_1 e := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.or (LLVM.and (LLVM.xor e_1 (LLVM.const? (-1))) e) e_1 ⊑ LLVM.or e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -370,8 +365,7 @@ theorem bitvec_AndOrXor_2113___A__B__A___A__B :
 
 theorem bitvec_AndOrXor_2118___A__B__A___A__B :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.or (LLVM.and e_1 e) (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) ⊑
-        LLVM.or (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e := by
+      LLVM.or (LLVM.and e_1 e) (LLVM.xor e_1 (LLVM.const? (-1))) ⊑ LLVM.or (LLVM.xor e_1 (LLVM.const? (-1))) e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -379,8 +373,7 @@ theorem bitvec_AndOrXor_2118___A__B__A___A__B :
   all_goals sorry
 
 theorem bitvec_AndOrXor_2123___A__B__A__B___A__B :
-    ∀ (e e_1 : LLVM.IntW w),
-      LLVM.or (LLVM.and e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0)))) (LLVM.xor e_1 e) ⊑ LLVM.xor e_1 e := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.or (LLVM.and e_1 (LLVM.xor e (LLVM.const? (-1)))) (LLVM.xor e_1 e) ⊑ LLVM.xor e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -389,9 +382,7 @@ theorem bitvec_AndOrXor_2123___A__B__A__B___A__B :
 
 theorem bitvec_AndOrXor_2188 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.or (LLVM.and e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))))
-          (LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) ⊑
-        LLVM.xor e_1 e := by
+      LLVM.or (LLVM.and e_1 (LLVM.xor e (LLVM.const? (-1)))) (LLVM.and (LLVM.xor e_1 (LLVM.const? (-1))) e) ⊑ LLVM.xor e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -416,8 +407,8 @@ theorem bitvec_AndOrXor_2243__B__C__A__B___B__A__C :
 
 theorem bitvec_AndOrXor_2247__A__B__A__B :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.or (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) (LLVM.xor e (LLVM.const? (Int.negSucc 0))) ⊑
-        LLVM.xor (LLVM.and e_1 e) (LLVM.const? (Int.negSucc 0)) := by
+      LLVM.or (LLVM.xor e_1 (LLVM.const? (-1))) (LLVM.xor e (LLVM.const? (-1))) ⊑
+        LLVM.xor (LLVM.and e_1 e) (LLVM.const? (-1)) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -434,8 +425,7 @@ theorem bitvec_AndOrXor_2263 :
 
 theorem bitvec_AndOrXor_2264 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.or e_1 (LLVM.xor (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) ⊑
-        LLVM.or e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+      LLVM.or e_1 (LLVM.xor (LLVM.xor e_1 (LLVM.const? (-1))) e) ⊑ LLVM.or e_1 (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -452,8 +442,7 @@ theorem bitvec_AndOrXor_2265 :
 
 theorem bitvec_AndOrXor_2284 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.or e_1 (LLVM.xor (LLVM.or e_1 e) (LLVM.const? (Int.negSucc 0))) ⊑
-        LLVM.or e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+      LLVM.or e_1 (LLVM.xor (LLVM.or e_1 e) (LLVM.const? (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -462,8 +451,7 @@ theorem bitvec_AndOrXor_2284 :
 
 theorem bitvec_AndOrXor_2285 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.or e_1 (LLVM.xor (LLVM.xor e_1 e) (LLVM.const? (Int.negSucc 0))) ⊑
-        LLVM.or e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+      LLVM.or e_1 (LLVM.xor (LLVM.xor e_1 e) (LLVM.const? (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -472,8 +460,7 @@ theorem bitvec_AndOrXor_2285 :
 
 theorem bitvec_AndOrXor_2297 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.or (LLVM.and e_1 e) (LLVM.xor (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) ⊑
-        LLVM.xor (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e := by
+      LLVM.or (LLVM.and e_1 e) (LLVM.xor (LLVM.xor e_1 (LLVM.const? (-1))) e) ⊑ LLVM.xor (LLVM.xor e_1 (LLVM.const? (-1))) e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -490,8 +477,8 @@ theorem bitvec_AndOrXor_2367 :
 
 theorem bitvec_AndOrXor_2416 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) (LLVM.const? (Int.negSucc 0)) ⊑
-        LLVM.or e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+      LLVM.xor (LLVM.and (LLVM.xor e_1 (LLVM.const? (-1))) e) (LLVM.const? (-1)) ⊑
+        LLVM.or e_1 (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -500,8 +487,8 @@ theorem bitvec_AndOrXor_2416 :
 
 theorem bitvec_AndOrXor_2417 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.or (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) (LLVM.const? (Int.negSucc 0)) ⊑
-        LLVM.and e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+      LLVM.xor (LLVM.or (LLVM.xor e_1 (LLVM.const? (-1))) e) (LLVM.const? (-1)) ⊑
+        LLVM.and e_1 (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -510,8 +497,8 @@ theorem bitvec_AndOrXor_2417 :
 
 theorem bitvec_AndOrXor_2429 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.and e_1 e) (LLVM.const? (Int.negSucc 0)) ⊑
-        LLVM.or (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+      LLVM.xor (LLVM.and e_1 e) (LLVM.const? (-1)) ⊑
+        LLVM.or (LLVM.xor e_1 (LLVM.const? (-1))) (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -520,8 +507,8 @@ theorem bitvec_AndOrXor_2429 :
 
 theorem bitvec_AndOrXor_2430 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.or e_1 e) (LLVM.const? (Int.negSucc 0)) ⊑
-        LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+      LLVM.xor (LLVM.or e_1 e) (LLVM.const? (-1)) ⊑
+        LLVM.and (LLVM.xor e_1 (LLVM.const? (-1))) (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -529,8 +516,7 @@ theorem bitvec_AndOrXor_2430 :
   all_goals sorry
 
 theorem bitvec_AndOrXor_2443 :
-    ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.ashr (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) (LLVM.const? (Int.negSucc 0)) ⊑ LLVM.ashr e_1 e := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.ashr (LLVM.xor e_1 (LLVM.const? (-1))) e) (LLVM.const? (-1)) ⊑ LLVM.ashr e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -539,7 +525,7 @@ theorem bitvec_AndOrXor_2443 :
 
 theorem bitvec_AndOrXor_2453 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.icmp LLVM.IntPredicate.slt e_1 e) (LLVM.const? (Int.negSucc 0)) ⊑ LLVM.icmp LLVM.IntPredicate.sge e_1 e := by
+      LLVM.xor (LLVM.icmp LLVM.IntPredicate.slt e_1 e) (LLVM.const? (-1)) ⊑ LLVM.icmp LLVM.IntPredicate.sge e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -547,8 +533,7 @@ theorem bitvec_AndOrXor_2453 :
   all_goals sorry
 
 theorem bitvec_AndOrXor_2475 :
-    ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.sub e_1 e) (LLVM.const? (Int.negSucc 0)) ⊑ LLVM.add e (LLVM.sub (LLVM.const? (Int.negSucc 0)) e_1) := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.sub e_1 e) (LLVM.const? (-1)) ⊑ LLVM.add e (LLVM.sub (LLVM.const? (-1)) e_1) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -556,8 +541,7 @@ theorem bitvec_AndOrXor_2475 :
   all_goals sorry
 
 theorem bitvec_AndOrXor_2486 :
-    ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.add e_1 e) (LLVM.const? (Int.negSucc 0)) ⊑ LLVM.sub (LLVM.sub (LLVM.const? (Int.negSucc 0)) e) e_1 := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.add e_1 e) (LLVM.const? (-1)) ⊑ LLVM.sub (LLVM.sub (LLVM.const? (-1)) e) e_1 := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -565,7 +549,7 @@ theorem bitvec_AndOrXor_2486 :
   all_goals sorry
 
 theorem bitvec_AndOrXor_2581__BAB___A__B :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.or e_1 e) e ⊑ LLVM.and e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))) := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.or e_1 e) e ⊑ LLVM.and e_1 (LLVM.xor e (LLVM.const? (-1))) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -573,7 +557,7 @@ theorem bitvec_AndOrXor_2581__BAB___A__B :
   all_goals sorry
 
 theorem bitvec_AndOrXor_2587__BAA___B__A :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.and e_1 e) e ⊑ LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.and e_1 e) e ⊑ LLVM.and (LLVM.xor e_1 (LLVM.const? (-1))) e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -590,9 +574,7 @@ theorem bitvec_AndOrXor_2595 :
 
 theorem bitvec_AndOrXor_2607 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.or e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))))
-          (LLVM.or (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) ⊑
-        LLVM.xor e_1 e := by
+      LLVM.xor (LLVM.or e_1 (LLVM.xor e (LLVM.const? (-1)))) (LLVM.or (LLVM.xor e_1 (LLVM.const? (-1))) e) ⊑ LLVM.xor e_1 e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -601,8 +583,7 @@ theorem bitvec_AndOrXor_2607 :
 
 theorem bitvec_AndOrXor_2617 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.and e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0))))
-          (LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e) ⊑
+      LLVM.xor (LLVM.and e_1 (LLVM.xor e (LLVM.const? (-1)))) (LLVM.and (LLVM.xor e_1 (LLVM.const? (-1))) e) ⊑
         LLVM.xor e_1 e := by
   simp_alive_undef
   simp_alive_ops
@@ -612,7 +593,7 @@ theorem bitvec_AndOrXor_2617 :
 
 theorem bitvec_AndOrXor_2627 :
     ∀ (e e_1 e_2 : LLVM.IntW w),
-      LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.xor (LLVM.and (LLVM.xor e_2 (LLVM.const? (Int.negSucc 0))) e) e_1 := by
+      LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.xor (LLVM.and (LLVM.xor e_2 (LLVM.const? (-1))) e) e_1 := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -629,8 +610,8 @@ theorem bitvec_AndOrXor_2647 :
 
 theorem bitvec_AndOrXor_2658 :
     ∀ (e e_1 : LLVM.IntW w),
-      LLVM.xor (LLVM.and e_1 (LLVM.xor e (LLVM.const? (Int.negSucc 0)))) (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) ⊑
-        LLVM.xor (LLVM.and e_1 e) (LLVM.const? (Int.negSucc 0)) := by
+      LLVM.xor (LLVM.and e_1 (LLVM.xor e (LLVM.const? (-1)))) (LLVM.xor e_1 (LLVM.const? (-1))) ⊑
+        LLVM.xor (LLVM.and e_1 e) (LLVM.const? (-1)) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -648,7 +629,7 @@ theorem bitvec_AndOrXor_2663 :
   all_goals sorry
 
 theorem bitvec_152 :
-    ∀ (e : LLVM.IntW w), LLVM.mul e (LLVM.const? (Int.negSucc 0)) ⊑ LLVM.sub (LLVM.const? 0) e := by
+    ∀ (e : LLVM.IntW w), LLVM.mul e (LLVM.const? (-1)) ⊑ LLVM.sub (LLVM.const? 0) e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -712,7 +693,7 @@ theorem bitvec_283 :
   all_goals sorry
 
 theorem bitvec_290__292 :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.mul (LLVM.shl (LLVM.const? ↑1) e_1) e ⊑ LLVM.shl e e_1 := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.mul (LLVM.shl (LLVM.const? 1) e_1) e ⊑ LLVM.shl e e_1 := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -736,7 +717,7 @@ theorem bitvec_820' :
   all_goals sorry
 
 theorem bitvec_1030 :
-    ∀ (e : LLVM.IntW w), LLVM.sdiv e (LLVM.const? (Int.negSucc 0)) ⊑ LLVM.sub (LLVM.const? 0) e := by
+    ∀ (e : LLVM.IntW w), LLVM.sdiv e (LLVM.const? (-1)) ⊑ LLVM.sub (LLVM.const? 0) e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -745,8 +726,7 @@ theorem bitvec_1030 :
 
 theorem bitvec_Select_858 :
     ∀ (e e_1 : LLVM.IntW 1),
-      LLVM.select e_1 (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e ⊑
-        LLVM.and (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e := by
+      LLVM.select e_1 (LLVM.xor e_1 (LLVM.const? (-1))) e ⊑ LLVM.and (LLVM.xor e_1 (LLVM.const? (-1))) e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -755,8 +735,7 @@ theorem bitvec_Select_858 :
 
 theorem bitvec_Select_859' :
     ∀ (e e_1 : LLVM.IntW 1),
-      LLVM.select e_1 e (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) ⊑
-        LLVM.or (LLVM.xor e_1 (LLVM.const? (Int.negSucc 0))) e := by
+      LLVM.select e_1 e (LLVM.xor e_1 (LLVM.const? (-1))) ⊑ LLVM.or (LLVM.xor e_1 (LLVM.const? (-1))) e := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -764,7 +743,7 @@ theorem bitvec_Select_859' :
   all_goals sorry
 
 theorem bitvec_select_1100 :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.select (LLVM.const? ↑1) e_1 e ⊑ e_1 := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.select (LLVM.const? 1) e_1 e ⊑ e_1 := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -780,7 +759,7 @@ theorem bitvec_Select_1105 :
   all_goals sorry
 
 theorem bitvec_InstCombineShift__239 :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.lshr (LLVM.shl e_1 e) e ⊑ LLVM.and e_1 (LLVM.lshr (LLVM.const? (Int.negSucc 0)) e) := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.lshr (LLVM.shl e_1 e) e ⊑ LLVM.and e_1 (LLVM.lshr (LLVM.const? (-1)) e) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -788,7 +767,7 @@ theorem bitvec_InstCombineShift__239 :
   all_goals sorry
 
 theorem bitvec_InstCombineShift__279 :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.shl (LLVM.lshr e_1 e) e ⊑ LLVM.and e_1 (LLVM.shl (LLVM.const? (Int.negSucc 0)) e) := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.shl (LLVM.lshr e_1 e) e ⊑ LLVM.and e_1 (LLVM.shl (LLVM.const? (-1)) e) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
@@ -832,7 +811,7 @@ theorem bitvec_InstCombineShift__497''' :
   all_goals sorry
 
 theorem bitvec_InstCombineShift__582 :
-    ∀ (e e_1 : LLVM.IntW w), LLVM.lshr (LLVM.shl e_1 e) e ⊑ LLVM.and e_1 (LLVM.lshr (LLVM.const? (Int.negSucc 0)) e) := by
+    ∀ (e e_1 : LLVM.IntW w), LLVM.lshr (LLVM.shl e_1 e) e ⊑ LLVM.and e_1 (LLVM.lshr (LLVM.const? (-1)) e) := by
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -84,6 +84,7 @@ lemma one_shiftLeft_mul_eq_shiftLeft {A B : BitVec w} :
   simp only [bv_toNat, Nat.mod_mul_mod, one_mul]
   rw [Nat.mul_comm]
 
+@[simp]
 def ofInt_zero_eq (w : Nat) : BitVec.ofInt w 0 = 0#w := rfl
 def ofNat_zero_eq (w : Nat) : BitVec.ofNat w 0 = 0#w := rfl
 def toInt_zero_eq (w : Nat) : BitVec.toInt 0#w = 0 := by
@@ -272,8 +273,7 @@ def one_sdiv { w : Nat} {a : BitVec w} (ha0 : a ≠ 0) (ha1 : a ≠ 1)
       unfold BitVec.sdiv
       simp [udiv_one_eq_self, msb_one, ofInt_one_eq_ofNat_one]
       by_cases h : BitVec.msb a <;> simp [h]
-      · simp [BitVec.ofInt_zero_eq]
-        simp only [neg_eq_iff_eq_neg, BitVec.neg_zero]
+      · simp only [neg_eq_iff_eq_neg, BitVec.neg_zero]
         apply BitVec.udiv_one_eq_zero
         apply BitVec.gt_one_of_neq_0_neq_1
         · rw [neg_neq_iff_neq_neg]
@@ -282,8 +282,7 @@ def one_sdiv { w : Nat} {a : BitVec w} (ha0 : a ≠ 0) (ha1 : a ≠ 1)
         · rw [neg_neq_iff_neq_neg]
           rw [← negOne_eq_allOnes] at hao
           assumption
-      · simp [BitVec.ofInt_zero_eq]
-        apply BitVec.udiv_one_eq_zero
+      · apply BitVec.udiv_one_eq_zero
         apply BitVec.gt_one_of_neq_0_neq_1 <;> assumption
 
 def sdiv_one_one' (h : 1 < w) : BitVec.sdiv 1#w 1#w = 1#w := by

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -86,6 +86,10 @@ lemma one_shiftLeft_mul_eq_shiftLeft {A B : BitVec w} :
 
 @[simp]
 def ofInt_zero_eq (w : Nat) : BitVec.ofInt w 0 = 0#w := rfl
+
+@[simp]
+def ofInt_one_eq (w : Nat) : BitVec.ofInt w 1 = 1#w := rfl
+
 def ofNat_zero_eq (w : Nat) : BitVec.ofNat w 0 = 0#w := rfl
 def toInt_zero_eq (w : Nat) : BitVec.toInt 0#w = 0 := by
  simp [BitVec.toInt]
@@ -95,6 +99,12 @@ def msb_ofInt_one (h : 1 < w): BitVec.msb (BitVec.ofInt w 1) = false := by
   simp only [BitVec.msb_eq_decide, decide_eq_false_iff_not, not_le, toNat_ofInt]
   norm_cast
   simp only [Int.toNat_natCast]
+  rw [Nat.mod_eq_of_lt] <;> simp <;> omega
+
+def msb_ofInt_one' (h : 1 < w): BitVec.msb (1#w) = false := by
+  simp only [BitVec.msb_eq_decide, decide_eq_false_iff_not, not_le, toNat_ofInt]
+  norm_cast
+  rw [BitVec.toNat_ofNat]
   rw [Nat.mod_eq_of_lt] <;> simp <;> omega
 
 @[simp]
@@ -127,7 +137,8 @@ lemma ofInt_ofNat (w n : Nat) :
 -- @[simp]
 def msb_one (h : 1 < w) : BitVec.msb (1#w) = false := by
   rw [← ofInt_ofNat]
-  simp [msb_ofInt_one h]
+  simp
+  simp [msb_ofInt_one' h]
 
 -- @[simp]
 def neg_allOnes {w : Nat} : -(allOnes w) = (1#w) := by
@@ -282,7 +293,8 @@ def one_sdiv { w : Nat} {a : BitVec w} (ha0 : a ≠ 0) (ha1 : a ≠ 1)
         · rw [neg_neq_iff_neq_neg]
           rw [← negOne_eq_allOnes] at hao
           assumption
-      · apply BitVec.udiv_one_eq_zero
+      ·
+        apply BitVec.udiv_one_eq_zero
         apply BitVec.gt_one_of_neq_0_neq_1 <;> assumption
 
 def sdiv_one_one' (h : 1 < w) : BitVec.sdiv 1#w 1#w = 1#w := by
@@ -305,15 +317,11 @@ def sdiv_one_one : BitVec.sdiv (BitVec.ofInt w 1) 1 = 1 := by
   unfold BitVec.udiv
   simp
   rw [msb_one (by omega)]
-  rw [msb_ofInt_one (by omega)]
   simp
   have ki' : (1) % (2) ^ w = 1 := by
     rw [Nat.mod_eq_of_lt]
     simp
     omega
-  have ki : (1:Int) % (2: Int) ^ w = 1 := by
-    norm_cast
-  simp only [ki]
   simp only [ki']
   simp
   have one : 1 = 1#w := by

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -128,7 +128,6 @@ lemma ofInt_ofNat' : BitVec.ofInt w (OfNat.ofNat (α := ℤ) x ) = x#w := rfl
 -- @[simp]
 def msb_one (h : 1 < w) : BitVec.msb (1#w) = false := by
   rw [← ofInt_ofNat]
-  simp
   simp [msb_ofInt_one h]
 
 -- @[simp]

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -84,12 +84,7 @@ lemma one_shiftLeft_mul_eq_shiftLeft {A B : BitVec w} :
   simp only [bv_toNat, Nat.mod_mul_mod, one_mul]
   rw [Nat.mul_comm]
 
-@[simp]
 def ofInt_zero_eq (w : Nat) : BitVec.ofInt w 0 = 0#w := rfl
-
-@[simp]
-def ofInt_one_eq (w : Nat) : BitVec.ofInt w 1 = 1#w := rfl
-
 def ofNat_zero_eq (w : Nat) : BitVec.ofNat w 0 = 0#w := rfl
 def toInt_zero_eq (w : Nat) : BitVec.toInt 0#w = 0 := by
  simp [BitVec.toInt]
@@ -99,12 +94,6 @@ def msb_ofInt_one (h : 1 < w): BitVec.msb 1#w = false := by
   simp only [BitVec.msb_eq_decide, decide_eq_false_iff_not, not_le, toNat_ofInt]
   norm_cast
   simp only [toNat_ofNat]
-  rw [Nat.mod_eq_of_lt] <;> simp <;> omega
-
-def msb_ofInt_one' (h : 1 < w): BitVec.msb (1#w) = false := by
-  simp only [BitVec.msb_eq_decide, decide_eq_false_iff_not, not_le, toNat_ofInt]
-  norm_cast
-  rw [BitVec.toNat_ofNat]
   rw [Nat.mod_eq_of_lt] <;> simp <;> omega
 
 @[simp]
@@ -140,7 +129,7 @@ lemma ofInt_ofNat' : BitVec.ofInt w (OfNat.ofNat (α := ℤ) x ) = x#w := rfl
 def msb_one (h : 1 < w) : BitVec.msb (1#w) = false := by
   rw [← ofInt_ofNat]
   simp
-  simp [msb_ofInt_one' h]
+  simp [msb_ofInt_one h]
 
 -- @[simp]
 def neg_allOnes {w : Nat} : -(allOnes w) = (1#w) := by

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -838,6 +838,11 @@ theorem ofBool_xor {a b : Bool} : BitVec.ofBool a ^^^ BitVec.ofBool b = ofBool (
 theorem ofBool_eq' : ofBool a = ofBool b ↔ a = b:= by
   rcases a <;> rcases b <;> simp [bv_toNat]
 
+theorem ofInt_negOne_eq_allOnes : BitVec.ofInt w (-1) = BitVec.allOnes w := by
+  norm_cast
+  rw [BitVec.ofInt_negSucc, ←BitVec.allOnes_sub_eq_not]
+  simp
+
 end BitVec
 
 -- Given (a, b) that are less than a modulus m, to show (a + b) % m < k, it suffices to consider two cases.

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -215,7 +215,7 @@ def mkComInstantiate (reg : MLIR.AST.Region φ) :
 end InstcombineTransformDialect
 
 register_option ssa.alive_icom_reduce : Bool := {
-  defValue := true
+  defValue := false
   group := "ssa"
   descr := "Controls whether the syntax [alive_icom| ... ] reduces the argument to normal form"
 }

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -248,7 +248,6 @@ elab "[alive_icom (" mvars:term,* ")| " reg:mlir_region "]" : term => do
   withTraceNode `alive_icom (return m!"{exceptEmoji ·} reduce") <|
     if ssa.alive_icom_reduce.get (← getOptions)
     then do
-      logWarningAt reg "simplifying proof state with reduction is deprecated, as it unstable across Lean versions. Recall that reduction in Lean is slow and heuristic based, and the heuristics can change across Lean versions. Suggestion: Find appropriate simp lemmas to simplify the proof state."
       reduce com
     else do
       return com

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -249,7 +249,6 @@ elab "[alive_icom (" mvars:term,* ")| " reg:mlir_region "]" : term => do
     if ssa.alive_icom_reduce.get (← getOptions)
     then reduce com
     else do
-      logInfoAt reg "reduction disabled"
       return com
 
 macro "[alive_icom| " reg:mlir_region "]" : term => `([alive_icom ()| $reg])

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -247,7 +247,9 @@ elab "[alive_icom (" mvars:term,* ")| " reg:mlir_region "]" : term => do
 
   withTraceNode `alive_icom (return m!"{exceptEmoji ·} reduce") <|
     if ssa.alive_icom_reduce.get (← getOptions)
-    then reduce com
+    then do
+      logWarningAt reg "simplifying proof state with reduction is deprecated, as it unstable across Lean versions. Recall that reduction in Lean is slow and heuristic based, and the heuristics can change across Lean versions. Suggestion: Find appropriate simp lemmas to simplify the proof state."
+      reduce com
     else do
       return com
 

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -71,7 +71,7 @@ macro "alive_auto": tactic =>
   `(tactic|
       (
         intros
-        simp (config := {failIfUnchanged := false}) [(BitVec.ofInt_eq_ofNat)]
+        simp (config := {failIfUnchanged := false}) [(BitVec.ofInt_negOne_eq_allOnes)]
         try ring_nf
         try solve | (ext; simp [BitVec.negOne_eq_allOnes];
                      try cases BitVec.getLsb _ _ <;> try simp;


### PR DESCRIPTION
This change is needed to update to lean 4.9. We commit this as a separate change, such that for future debugging sessions there is a commit where easily both versions can be inspected.