### PR TITLE
Fix: Make the generic MLIR parser hygiene resistant

### DIFF
--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -665,27 +665,24 @@ attrVal10Float
 # MLIR ATTRIBUTE
 -/
 
-declare_syntax_cat mlir_attr_entry
+syntax mlir_attr_key := ident <|> strLit
+syntax mlir_attr_entry := mlir_attr_key (" = " mlir_attr_val)?
 
-syntax ident "=" mlir_attr_val : mlir_attr_entry
-syntax strLit "=" mlir_attr_val : mlir_attr_entry
-syntax ident : mlir_attr_entry
-
-syntax "[mlir_attr_entry|" mlir_attr_entry "]" : term
-
--- | TODO: don't actually write an elaborator for the `ident` case. This forces
--- us to declare predefined identifiers in a controlled fashion.
-macro_rules
-  | `([mlir_attr_entry| $name:ident  = $v:mlir_attr_val]) =>
-     `(AttrEntry.mk $(Lean.quote (name.getId.toString))  [mlir_attr_val| $v])
-  | `([mlir_attr_entry| $name:str  = $v:mlir_attr_val]) =>
-     `(AttrEntry.mk $name [mlir_attr_val| $v])
-
-macro_rules
-  | `([mlir_attr_entry| $name:ident]) =>
-     `(AttrEntry.mk $(Lean.quote (name.getId.toString))  AttrValue.unit)
-
-
+macro "[mlir_attr_entry|" entry:mlir_attr_entry "]" : term => do
+  let `(mlir_attr_entry| $key $[= $val]?) := entry | Macro.throwUnsupported
+  let key ← match key.raw[0] with
+    | .ident _ key _ _ => pure key.toString
+    --         ^^^ Notice we don't use the `val`, since the name might have been hygiene'd
+    --             Instead, we use `rawVal`, which is documented as being
+    --               "the literal substring from the input file" thus safe from hygiene
+    | .node _ `str ⟨(.atom _ val)::[]⟩ => pure val
+    -- ^^^ The `strLit` case
+    | _ => Macro.throwUnsupported
+    -- TODO: handle strLit case
+  let value ← match val with
+    | none      => `(AttrValue.unit)
+    | some val  => `([mlir_attr_val| $val])
+  `(AttrEntry.mk $(Lean.quote key) $value)
 
 def attr0Str : AttrEntry 0 := [mlir_attr_entry| sym_name = "add"]
 /--

--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -294,16 +294,16 @@ syntax "!" ident : mlir_type
 syntax ident: mlir_type
 syntax "_" : mlir_type
 
-
 macro_rules
   | `([mlir_type| $x:ident ]) => do
-        let xstr := x.getId.toString
+        let (.ident _ xstr _ _) := x.raw | Macro.throwUnsupported
+        -- ^^ We use `rawVal` rather than `val`, so that we're not affected by hygiene
         if xstr == "index"
         then
           `(MLIRType.index)
         else if xstr.front == 'i' || xstr.front == 'f'
         then do
-          let xstr' := xstr.drop 1
+          let xstr' := (xstr.drop 1).toString
           match xstr'.toInt? with
           | some _ =>
             let lit := Lean.Syntax.mkNumLit xstr'
@@ -311,8 +311,8 @@ macro_rules
             then `(MLIRType.int .Signless $lit)
             else `(MLIRType.float $lit)
           | none =>
-              Macro.throwError $ "cannot convert suffix of i/f to int: " ++ xstr
-        else Macro.throwError $ "expected i<int> or f<int>, found: " ++ xstr
+              Macro.throwError $ "cannot convert suffix of i/f to int: " ++ xstr.toString
+        else Macro.throwError $ "expected i<int> or f<int>, found: " ++ xstr.toString
   | `([mlir_type| ! $x:str ]) => `(MLIRType.undefined $x)
   | `([mlir_type| ! $x:ident ]) => `(MLIRType.undefined $(Lean.quote x.getId.toString))
   -- Hardcoded meta-variable

--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -678,7 +678,6 @@ macro "[mlir_attr_entry|" entry:mlir_attr_entry "]" : term => do
     | .node _ `str ⟨(.atom _ val)::[]⟩ => pure val
     -- ^^^ The `strLit` case
     | _ => Macro.throwUnsupported
-    -- TODO: handle strLit case
   let value ← match val with
     | none      => `(AttrValue.unit)
     | some val  => `([mlir_attr_val| $val])


### PR DESCRIPTION
This changes various parts of the MLIR generic parser to inspect the `rawVal` of an identifier, rather than the `val`. This raw value is literally the substring of the input value that corresponds to the identifier, and is thus not affected by hygiene.

This becomes especially relevant if we want to generate MLIR syntax with macros, since we don't want our types and attributes, which use identifiers in the parser, to be affected by hygiene. In particular, this patch removes the need for a `set_option hygiene false` in #359 