### PR TITLE
feat: support negative constants in the pretty edsl

### DIFF
--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -2,6 +2,8 @@ import SSA.Core.MLIRSyntax.GenericParser
 import SSA.Projects.InstCombine.Tactic
 open Lean
 
+namespace MLIR.EDSL
+
 declare_syntax_cat InstCombine.un_op_name
 declare_syntax_cat InstCombine.bin_op_name
 
@@ -53,13 +55,14 @@ macro_rules
     let t ← t.getDM `(mlir_type| _)
     `(mlir_op| $resName:mlir_op_operand = $opName ($x, $y) : ($t, $t) -> ($t) )
 
-syntax mlir_op_operand " = " "llvm.mlir.constant" num (" : " mlir_type)? : mlir_op
+syntax mlir_op_operand " = " "llvm.mlir.constant" neg_num (" : " mlir_type)? : mlir_op
 macro_rules
   | `(mlir_op| $res:mlir_op_operand = llvm.mlir.constant $x $[: $t]?) => do
     let t ← t.getDM `(mlir_type| _)
-    `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = $x:num : $t} : () -> ($t) )
+    `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = $x:neg_num : $t} : () -> ($t) )
 
 
+section Test
 
 private def pretty_test :=
   [alive_icom ()|{
@@ -91,5 +94,13 @@ private def prettier_test_generic (w : Nat) :=
     llvm.return %3
   }]
 
+private def neg_constant (w : Nat) :=
+  [alive_icom (w)| {
+    %0 = llvm.mlir.constant -1
+    llvm.return %0
+  }]
+
 example : pretty_test         = prettier_test_generic 32 := rfl
 example : pretty_test_generic = prettier_test_generic    := rfl
+
+end Test


### PR DESCRIPTION
This fixes an issue raised in #369, where the constant `-1` failed to parse in the concise syntax.

In the process, the generic edsl was also changed so that constant without type ascription are always assumed to be signless (rather than the type depending on whether the value is negative or not).