### PR TITLE
feat: convert to llvm pretty and support for llvm.icmp

### DIFF
--- a/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
@@ -31,17 +31,17 @@ precondition: true
 def alive_DivRemOfSelect_src (w : Nat) :=
   [alive_icom (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
-    %c0 = llvm.mlir.constant 0 : _
-    %v1 = llvm.select %c, %y, %c0 : _
-    %v2 = llvm.udiv %x,  %v1 : _
-    llvm.return %v2 : _
+    %c0 = llvm.mlir.constant 0
+    %v1 = llvm.select %c, %y, %c0
+    %v2 = llvm.udiv %x,  %v1
+    llvm.return %v2
   }]
 
 def alive_DivRemOfSelect_tgt (w : Nat) :=
   [alive_icom (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
-    %v1 = llvm.udiv %x, %y : _
-    llvm.return %v1 : _
+    %v1 = llvm.udiv %x, %y
+    llvm.return %v1
   }]
 
 @[simp]

--- a/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
@@ -1,7 +1,7 @@
 /-
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import SSA.Projects.InstCombine.LLVM.EDSL
+import SSA.Projects.InstCombine.LLVM.PrettyEDSL
 import SSA.Projects.InstCombine.AliveStatements
 import SSA.Projects.InstCombine.Refinement
 import SSA.Projects.InstCombine.Tactic
@@ -31,17 +31,17 @@ precondition: true
 def alive_DivRemOfSelect_src (w : Nat) :=
   [alive_icom (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
-    %c0 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-    %v1 = "llvm.select" (%c,%y, %c0) : (i1, _, _) -> (_)
-    %v2 = "llvm.udiv"(%x, %v1) : (_, _) -> (_)
-    "llvm.return" (%v2) : (_) -> ()
+    %c0 = llvm.mlir.constant 0 : _
+    %v1 = llvm.select %c, %y, %c0 : _
+    %v2 = llvm.udiv %x,  %v1 : _
+    llvm.return %v2 : _
   }]
 
 def alive_DivRemOfSelect_tgt (w : Nat) :=
   [alive_icom (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
-    %v1 = "llvm.udiv" (%x,%y) : (_, _) -> (_)
-    "llvm.return" (%v1) : (_) -> ()
+    %v1 = llvm.udiv %x, %y : _
+    llvm.return %v1 : _
   }]
 
 @[simp]

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -1,6 +1,6 @@
 import SSA.Projects.InstCombine.ComWrappers
 import SSA.Projects.InstCombine.ForLean
-import SSA.Projects.InstCombine.LLVM.EDSL
+import SSA.Projects.InstCombine.LLVM.PrettyEDSL
 import SSA.Projects.InstCombine.Tactic
 import SSA.Projects.InstCombine.TacticAuto
 import SSA.Projects.InstCombine.ComWrappers
@@ -24,17 +24,17 @@ precondition: true
 def alive_DivRemOfSelect_src (w : Nat) :=
   [alive_icom (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
-    %c0 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-    %v1 = "llvm.select" (%c,%y, %c0) : (i1, _, _) -> (_)
-    %v2 = "llvm.udiv"(%x, %v1) : (_, _) -> (_)
-    "llvm.return" (%v2) : (_) -> ()
+    %c0 = llvm.mlir.constant 0 : _
+    %v1 = llvm.select %c, %y, %c0 : _
+    %v2 = llvm.udiv %x,  %v1 : _
+    llvm.return %v2 : _
   }]
 
 def alive_DivRemOfSelect_tgt (w : Nat) :=
   [alive_icom (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
-    %v1 = "llvm.udiv" (%x,%y) : (_, _) -> (_)
-    "llvm.return" (%v1) : (_) -> ()
+    %v1 = llvm.udiv %x, %y : _
+    llvm.return %v1 : _
   }]
 
 theorem alive_DivRemOfSelect (w : Nat) :

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -24,17 +24,17 @@ precondition: true
 def alive_DivRemOfSelect_src (w : Nat) :=
   [alive_icom (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
-    %c0 = llvm.mlir.constant 0 : _
-    %v1 = llvm.select %c, %y, %c0 : _
-    %v2 = llvm.udiv %x,  %v1 : _
-    llvm.return %v2 : _
+    %c0 = llvm.mlir.constant 0
+    %v1 = llvm.select %c, %y, %c0
+    %v2 = llvm.udiv %x,  %v1
+    llvm.return %v2
   }]
 
 def alive_DivRemOfSelect_tgt (w : Nat) :=
   [alive_icom (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
-    %v1 = llvm.udiv %x, %y : _
-    llvm.return %v1 : _
+    %v1 = llvm.udiv %x, %y
+    llvm.return %v1
   }]
 
 theorem alive_DivRemOfSelect (w : Nat) :

--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -7,7 +7,6 @@ import SSA.Projects.InstCombine.ForStd
 import SSA.Projects.InstCombine.ForMathlib
 import SSA.Projects.InstCombine.LLVM.Semantics
 import Batteries.Data.BitVec
-import Mathlib.Data.BitVec.Lemmas
 
 open LLVM
 open BitVec

--- a/SSA/Projects/InstCombine/ForMathlib.lean
+++ b/SSA/Projects/InstCombine/ForMathlib.lean
@@ -10,7 +10,7 @@ open Nat
 theorem ofInt_negSucc (w n : Nat ) :
     BitVec.ofInt w (Int.negSucc n) = ~~~.ofNat w n := by
   simp [BitVec.ofInt]
-  apply BitVec.toNat_injective
+  rw [BitVec.toNat_eq]
   simp only [Int.toNat, toNat_ofNatLt, toNat_not, toNat_ofNat]
   split
   · simp_all [Int.negSucc_emod]

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -6,6 +6,7 @@ namespace MLIR.EDSL
 
 declare_syntax_cat InstCombine.un_op_name
 declare_syntax_cat InstCombine.bin_op_name
+declare_syntax_cat InstCombine.cmp_op_name
 
 syntax "llvm.return"  : InstCombine.un_op_name
 syntax "llvm.copy"    : InstCombine.un_op_name
@@ -25,6 +26,17 @@ syntax "llvm.sub"     : InstCombine.bin_op_name
 syntax "llvm.udiv"    : InstCombine.bin_op_name
 syntax "llvm.urem"    : InstCombine.bin_op_name
 syntax "llvm.xor"     : InstCombine.bin_op_name
+
+syntax "llvm.icmp.eq"  : InstCombine.cmp_op_name
+syntax "llvm.icmp.ne"  : InstCombine.cmp_op_name
+syntax "llvm.icmp.slt" : InstCombine.cmp_op_name
+syntax "llvm.icmp.sle" : InstCombine.cmp_op_name
+syntax "llvm.icmp.sgt" : InstCombine.cmp_op_name
+syntax "llvm.icmp.sge" : InstCombine.cmp_op_name
+syntax "llvm.icmp.ult" : InstCombine.cmp_op_name
+syntax "llvm.icmp.ule" : InstCombine.cmp_op_name
+syntax "llvm.icmp.ugt" : InstCombine.cmp_op_name
+syntax "llvm.icmp.uge" : InstCombine.cmp_op_name
 
 -- TODO: does `icmp` need its own case?
 
@@ -48,11 +60,20 @@ macro_rules
 syntax mlir_op_operand " = " InstCombine.bin_op_name mlir_op_operand ", " mlir_op_operand
         (" : " mlir_type)? : mlir_op
 macro_rules
-  | `(mlir_op| $resName:mlir_op_operand = $name $x, $y $[: $t]?) => do
+  | `(mlir_op| $resName:mlir_op_operand = $name:InstCombine.bin_op_name $x, $y $[: $t]?) => do
     let some opName := extractOpName name.raw
       | Macro.throwUnsupported
     let t ← t.getDM `(mlir_type| _)
     `(mlir_op| $resName:mlir_op_operand = $opName ($x, $y) : ($t, $t) -> ($t) )
+
+syntax mlir_op_operand " = " InstCombine.cmp_op_name mlir_op_operand ", " mlir_op_operand
+        (" : " mlir_type)? : mlir_op
+macro_rules
+  | `(mlir_op| $resName:mlir_op_operand = $name:InstCombine.cmp_op_name $x, $y $[: $t]?) => do
+    let some opName := extractOpName name.raw
+      | Macro.throwUnsupported
+    let t ← t.getDM `(mlir_type| _)
+    `(mlir_op| $resName:mlir_op_operand = $opName ($x, $y) : ($t, $t) -> (i1) )
 
 syntax mlir_op_operand " = " "llvm.mlir.constant" neg_num (" : " mlir_type)? : mlir_op
 macro_rules

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -38,8 +38,8 @@ syntax "llvm.icmp.ule" : InstCombine.cmp_op_name
 syntax "llvm.icmp.ugt" : InstCombine.cmp_op_name
 syntax "llvm.icmp.uge" : InstCombine.cmp_op_name
 
-/-- Given syntax of category `un_op_name` or `bin_op_name`, extract the name of the operation and
-return it as a string literal syntax -/
+/-- /-- Given syntax of category `un_op_name`, `bin_op_name`, or `cmp_op_name`,
+extract the name of the operation and return it as a string literal syntax. -/
 def extractOpName : Syntax → Option (TSyntax `str)
   | .node _ _ ⟨.atom _ name :: _⟩ => some <| Syntax.mkStrLit name
   | _ => none

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -55,7 +55,7 @@ macro_rules
       | none => #[]
     `([mlir_op| $[$resName =]? $opName ($x) : ($t) -> ($retTy:mlir_type,*) ])
 
-syntax mlir_op_operand " = " InstCombine.bin_op_name mlir_op_operand ", " mlir_op_operand
+syntax mlir_op_operand " = " (InstCombine.bin_op_name <|> InstCombine.cmp_op_name) mlir_op_operand ", " mlir_op_operand
         (" : " mlir_type)? : mlir_op
 macro_rules
   | `(mlir_op| $resName:mlir_op_operand = $name:InstCombine.bin_op_name $x, $y $[: $t]?) => do

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -64,8 +64,6 @@ macro_rules
     let t ← t.getDM `(mlir_type| _)
     `(mlir_op| $resName:mlir_op_operand = $opName ($x, $y) : ($t, $t) -> ($t) )
 
-syntax mlir_op_operand " = " InstCombine.cmp_op_name mlir_op_operand ", " mlir_op_operand
-        (" : " mlir_type)? : mlir_op
 macro_rules
   | `(mlir_op| $resName:mlir_op_operand = $name:InstCombine.cmp_op_name $x, $y $[: $t]?) => do
     let some opName := extractOpName name.raw

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -38,7 +38,7 @@ syntax "llvm.icmp.ule" : InstCombine.cmp_op_name
 syntax "llvm.icmp.ugt" : InstCombine.cmp_op_name
 syntax "llvm.icmp.uge" : InstCombine.cmp_op_name
 
-/-- /-- Given syntax of category `un_op_name`, `bin_op_name`, or `cmp_op_name`,
+/-- Given syntax of category `un_op_name`, `bin_op_name`, or `cmp_op_name`,
 extract the name of the operation and return it as a string literal syntax. -/
 def extractOpName : Syntax → Option (TSyntax `str)
   | .node _ _ ⟨.atom _ name :: _⟩ => some <| Syntax.mkStrLit name

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -38,8 +38,6 @@ syntax "llvm.icmp.ule" : InstCombine.cmp_op_name
 syntax "llvm.icmp.ugt" : InstCombine.cmp_op_name
 syntax "llvm.icmp.uge" : InstCombine.cmp_op_name
 
--- TODO: does `icmp` need its own case?
-
 /-- Given syntax of category `un_op_name` or `bin_op_name`, extract the name of the operation and
 return it as a string literal syntax -/
 def extractOpName : Syntax → Option (TSyntax `str)

--- a/SSA/Projects/InstCombine/ScalingTest.lean
+++ b/SSA/Projects/InstCombine/ScalingTest.lean
@@ -30,24 +30,24 @@ set_option maxHeartbeats 400000
 def and_sequence_10_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z, %C1 : _
-  %v2 = llvm.and %v1, %C1 : _
-  %v3 = llvm.and %v2, %C1 : _
-  %v4 = llvm.and %v3, %C1 : _
-  %v5 = llvm.and %v4, %C1 : _
-  %v6 = llvm.and %v5, %C1 : _
-  %v7 = llvm.and %v6, %C1 : _
-  %v8 = llvm.and %v7, %C1 : _
-  %v9 = llvm.and %v8, %C1 : _
-  %v10 = llvm.and %v9, %C1 : _
-  llvm.return %v10 : _
+  %v1 = llvm.and %Z, %C1
+  %v2 = llvm.and %v1, %C1
+  %v3 = llvm.and %v2, %C1
+  %v4 = llvm.and %v3, %C1
+  %v5 = llvm.and %v4, %C1
+  %v6 = llvm.and %v5, %C1
+  %v7 = llvm.and %v6, %C1
+  %v8 = llvm.and %v7, %C1
+  %v9 = llvm.and %v8, %C1
+  %v10 = llvm.and %v9, %C1
+  llvm.return %v10
 }]
 
 def and_sequence_10_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z,  %C1 : _
-  llvm.return %v1 : _
+  %v1 = llvm.and %Z,  %C1
+  llvm.return %v1
 }]
 
 theorem and_sequence_10_eq (w : Nat) :
@@ -62,27 +62,27 @@ theorem and_sequence_10_eq (w : Nat) :
 def and_sequence_15_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z, %C1 : _
-  %v2 = llvm.and %v1, %C1 : _
-  %v3 = llvm.and %v2, %C1 : _
-  %v4 = llvm.and %v3, %C1 : _
-  %v5 = llvm.and %v4, %C1 : _
-  %v6 = llvm.and %v5, %C1 : _
-  %v7 = llvm.and %v6, %C1 : _
-  %v8 = llvm.and %v7, %C1 : _
-  %v9 = llvm.and %v8, %C1 : _
-  %v10 = llvm.and %v9, %C1 : _
-  %v11 = llvm.and %v10, %C1 : _
-  %v12 = llvm.and %v11, %C1 : _
-  %v13 = llvm.and %v12, %C1 : _
-  llvm.return %v13 : _
+  %v1 = llvm.and %Z, %C1
+  %v2 = llvm.and %v1, %C1
+  %v3 = llvm.and %v2, %C1
+  %v4 = llvm.and %v3, %C1
+  %v5 = llvm.and %v4, %C1
+  %v6 = llvm.and %v5, %C1
+  %v7 = llvm.and %v6, %C1
+  %v8 = llvm.and %v7, %C1
+  %v9 = llvm.and %v8, %C1
+  %v10 = llvm.and %v9, %C1
+  %v11 = llvm.and %v10, %C1
+  %v12 = llvm.and %v11, %C1
+  %v13 = llvm.and %v12, %C1
+  llvm.return %v13
 }]
 
 def and_sequence_15_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z,  %C1 : _
-  llvm.return %v1 : _
+  %v1 = llvm.and %Z,  %C1
+  llvm.return %v1
 }]
 
 theorem and_sequence_15_eq (w : Nat) :
@@ -98,34 +98,34 @@ set_option maxHeartbeats 500000 in
 def and_sequence_20_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z, %C1 : _
-  %v2 = llvm.and %v1, %C1 : _
-  %v3 = llvm.and %v2, %C1 : _
-  %v4 = llvm.and %v3, %C1 : _
-  %v5 = llvm.and %v4, %C1 : _
-  %v6 = llvm.and %v5, %C1 : _
-  %v7 = llvm.and %v6, %C1 : _
-  %v8 = llvm.and %v7, %C1 : _
-  %v9 = llvm.and %v8, %C1 : _
-  %v10 = llvm.and %v9, %C1 : _
-  %v11 = llvm.and %v10, %C1 : _
-  %v12 = llvm.and %v11, %C1 : _
-  %v13 = llvm.and %v12, %C1 : _
-  %v14 = llvm.and %v13, %C1 : _
-  %v15 = llvm.and %v14, %C1 : _
-  %v16 = llvm.and %v15, %C1 : _
-  %v17 = llvm.and %v16, %C1 : _
-  %v18 = llvm.and %v17, %C1 : _
-  %v19 = llvm.and %v18, %C1 : _
-  %v20 = llvm.and %v19, %C1 : _
-  llvm.return %v20 : _
+  %v1 = llvm.and %Z, %C1
+  %v2 = llvm.and %v1, %C1
+  %v3 = llvm.and %v2, %C1
+  %v4 = llvm.and %v3, %C1
+  %v5 = llvm.and %v4, %C1
+  %v6 = llvm.and %v5, %C1
+  %v7 = llvm.and %v6, %C1
+  %v8 = llvm.and %v7, %C1
+  %v9 = llvm.and %v8, %C1
+  %v10 = llvm.and %v9, %C1
+  %v11 = llvm.and %v10, %C1
+  %v12 = llvm.and %v11, %C1
+  %v13 = llvm.and %v12, %C1
+  %v14 = llvm.and %v13, %C1
+  %v15 = llvm.and %v14, %C1
+  %v16 = llvm.and %v15, %C1
+  %v17 = llvm.and %v16, %C1
+  %v18 = llvm.and %v17, %C1
+  %v19 = llvm.and %v18, %C1
+  %v20 = llvm.and %v19, %C1
+  llvm.return %v20
 }]
 
 def and_sequence_20_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z,  %C1 : _
-  llvm.return %v1 : _
+  %v1 = llvm.and %Z,  %C1
+  llvm.return %v1
 }]
 
 theorem and_sequence_20_eq (w : Nat) :
@@ -141,44 +141,44 @@ set_option maxHeartbeats 1700000 in
 def and_sequence_30_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z, %C1 : _
-  %v2 = llvm.and %v1, %C1 : _
-  %v3 = llvm.and %v2, %C1 : _
-  %v4 = llvm.and %v3, %C1 : _
-  %v5 = llvm.and %v4, %C1 : _
-  %v6 = llvm.and %v5, %C1 : _
-  %v7 = llvm.and %v6, %C1 : _
-  %v8 = llvm.and %v7, %C1 : _
-  %v9 = llvm.and %v8, %C1 : _
-  %v10 = llvm.and %v9, %C1 : _
-  %v11 = llvm.and %v10, %C1 : _
-  %v12 = llvm.and %v11, %C1 : _
-  %v13 = llvm.and %v12, %C1 : _
-  %v14 = llvm.and %v13, %C1 : _
-  %v15 = llvm.and %v14, %C1 : _
-  %v16 = llvm.and %v15, %C1 : _
-  %v17 = llvm.and %v16, %C1 : _
-  %v18 = llvm.and %v17, %C1 : _
-  %v19 = llvm.and %v18, %C1 : _
-  %v20 = llvm.and %v19, %C1 : _
-  %v21 = llvm.and %v20, %C1 : _
-  %v22 = llvm.and %v21, %C1 : _
-  %v23 = llvm.and %v22, %C1 : _
-  %v24 = llvm.and %v23, %C1 : _
-  %v25 = llvm.and %v24, %C1 : _
-  %v26 = llvm.and %v25, %C1 : _
-  %v27 = llvm.and %v26, %C1 : _
-  %v28 = llvm.and %v27, %C1 : _
-  %v29 = llvm.and %v28, %C1 : _
-  %v30 = llvm.and %v29, %C1 : _
-  llvm.return %v30 : _
+  %v1 = llvm.and %Z, %C1
+  %v2 = llvm.and %v1, %C1
+  %v3 = llvm.and %v2, %C1
+  %v4 = llvm.and %v3, %C1
+  %v5 = llvm.and %v4, %C1
+  %v6 = llvm.and %v5, %C1
+  %v7 = llvm.and %v6, %C1
+  %v8 = llvm.and %v7, %C1
+  %v9 = llvm.and %v8, %C1
+  %v10 = llvm.and %v9, %C1
+  %v11 = llvm.and %v10, %C1
+  %v12 = llvm.and %v11, %C1
+  %v13 = llvm.and %v12, %C1
+  %v14 = llvm.and %v13, %C1
+  %v15 = llvm.and %v14, %C1
+  %v16 = llvm.and %v15, %C1
+  %v17 = llvm.and %v16, %C1
+  %v18 = llvm.and %v17, %C1
+  %v19 = llvm.and %v18, %C1
+  %v20 = llvm.and %v19, %C1
+  %v21 = llvm.and %v20, %C1
+  %v22 = llvm.and %v21, %C1
+  %v23 = llvm.and %v22, %C1
+  %v24 = llvm.and %v23, %C1
+  %v25 = llvm.and %v24, %C1
+  %v26 = llvm.and %v25, %C1
+  %v27 = llvm.and %v26, %C1
+  %v28 = llvm.and %v27, %C1
+  %v29 = llvm.and %v28, %C1
+  %v30 = llvm.and %v29, %C1
+  llvm.return %v30
 }]
 
 def and_sequence_30_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z,  %C1 : _
-  llvm.return %v1 : _
+  %v1 = llvm.and %Z,  %C1
+  llvm.return %v1
 }]
 
 theorem and_sequence_30_eq (w : Nat) :
@@ -195,54 +195,54 @@ set_option maxRecDepth 1500 in
 def and_sequence_40_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z, %C1 : _
-  %v2 = llvm.and %v1, %C1 : _
-  %v3 = llvm.and %v2, %C1 : _
-  %v4 = llvm.and %v3, %C1 : _
-  %v5 = llvm.and %v4, %C1 : _
-  %v6 = llvm.and %v5, %C1 : _
-  %v7 = llvm.and %v6, %C1 : _
-  %v8 = llvm.and %v7, %C1 : _
-  %v9 = llvm.and %v8, %C1 : _
-  %v10 = llvm.and %v9, %C1 : _
-  %v11 = llvm.and %v10, %C1 : _
-  %v12 = llvm.and %v11, %C1 : _
-  %v13 = llvm.and %v12, %C1 : _
-  %v14 = llvm.and %v13, %C1 : _
-  %v15 = llvm.and %v14, %C1 : _
-  %v16 = llvm.and %v15, %C1 : _
-  %v17 = llvm.and %v16, %C1 : _
-  %v18 = llvm.and %v17, %C1 : _
-  %v19 = llvm.and %v18, %C1 : _
-  %v20 = llvm.and %v19, %C1 : _
-  %v21 = llvm.and %v20, %C1 : _
-  %v22 = llvm.and %v21, %C1 : _
-  %v23 = llvm.and %v22, %C1 : _
-  %v24 = llvm.and %v23, %C1 : _
-  %v25 = llvm.and %v24, %C1 : _
-  %v26 = llvm.and %v25, %C1 : _
-  %v27 = llvm.and %v26, %C1 : _
-  %v28 = llvm.and %v27, %C1 : _
-  %v29 = llvm.and %v28, %C1 : _
-  %v30 = llvm.and %v29, %C1 : _
-  %v31 = llvm.and %v30, %C1 : _
-  %v32 = llvm.and %v31, %C1 : _
-  %v33 = llvm.and %v32, %C1 : _
-  %v34 = llvm.and %v33, %C1 : _
-  %v35 = llvm.and %v34, %C1 : _
-  %v36 = llvm.and %v35, %C1 : _
-  %v37 = llvm.and %v36, %C1 : _
-  %v38 = llvm.and %v37, %C1 : _
-  %v39 = llvm.and %v38, %C1 : _
-  %v40 = llvm.and %v39, %C1 : _
-  llvm.return %v40 : _
+  %v1 = llvm.and %Z, %C1
+  %v2 = llvm.and %v1, %C1
+  %v3 = llvm.and %v2, %C1
+  %v4 = llvm.and %v3, %C1
+  %v5 = llvm.and %v4, %C1
+  %v6 = llvm.and %v5, %C1
+  %v7 = llvm.and %v6, %C1
+  %v8 = llvm.and %v7, %C1
+  %v9 = llvm.and %v8, %C1
+  %v10 = llvm.and %v9, %C1
+  %v11 = llvm.and %v10, %C1
+  %v12 = llvm.and %v11, %C1
+  %v13 = llvm.and %v12, %C1
+  %v14 = llvm.and %v13, %C1
+  %v15 = llvm.and %v14, %C1
+  %v16 = llvm.and %v15, %C1
+  %v17 = llvm.and %v16, %C1
+  %v18 = llvm.and %v17, %C1
+  %v19 = llvm.and %v18, %C1
+  %v20 = llvm.and %v19, %C1
+  %v21 = llvm.and %v20, %C1
+  %v22 = llvm.and %v21, %C1
+  %v23 = llvm.and %v22, %C1
+  %v24 = llvm.and %v23, %C1
+  %v25 = llvm.and %v24, %C1
+  %v26 = llvm.and %v25, %C1
+  %v27 = llvm.and %v26, %C1
+  %v28 = llvm.and %v27, %C1
+  %v29 = llvm.and %v28, %C1
+  %v30 = llvm.and %v29, %C1
+  %v31 = llvm.and %v30, %C1
+  %v32 = llvm.and %v31, %C1
+  %v33 = llvm.and %v32, %C1
+  %v34 = llvm.and %v33, %C1
+  %v35 = llvm.and %v34, %C1
+  %v36 = llvm.and %v35, %C1
+  %v37 = llvm.and %v36, %C1
+  %v38 = llvm.and %v37, %C1
+  %v39 = llvm.and %v38, %C1
+  %v40 = llvm.and %v39, %C1
+  llvm.return %v40
 }]
 
 def and_sequence_40_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = llvm.and %Z,  %C1 : _
-  llvm.return %v1 : _
+  %v1 = llvm.and %Z,  %C1
+  llvm.return %v1
 }]
 
 set_option maxHeartbeats 800000 in

--- a/SSA/Projects/InstCombine/ScalingTest.lean
+++ b/SSA/Projects/InstCombine/ScalingTest.lean
@@ -3,6 +3,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
 import SSA.Projects.InstCombine.LLVM.Semantics
+import SSA.Projects.InstCombine.LLVM.PrettyEDSL
 import SSA.Projects.InstCombine.Tactic
 import SSA.Projects.InstCombine.TacticAuto
 
@@ -29,24 +30,24 @@ set_option maxHeartbeats 400000
 def and_sequence_10_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z,%C1) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%C1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%C1) : (_, _) -> (_)
-  %v4 = "llvm.and" (%v3,%C1) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v4,%C1) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v5,%C1) : (_, _) -> (_)
-  %v7 = "llvm.and" (%v6,%C1) : (_, _) -> (_)
-  %v8 = "llvm.and" (%v7,%C1) : (_, _) -> (_)
-  %v9 = "llvm.and" (%v8,%C1) : (_, _) -> (_)
-  %v10 = "llvm.and" (%v9,%C1) : (_, _) -> (_)
-  "llvm.return" (%v10) : (_) -> ()
+  %v1 = llvm.and %Z, %C1 : _
+  %v2 = llvm.and %v1, %C1 : _
+  %v3 = llvm.and %v2, %C1 : _
+  %v4 = llvm.and %v3, %C1 : _
+  %v5 = llvm.and %v4, %C1 : _
+  %v6 = llvm.and %v5, %C1 : _
+  %v7 = llvm.and %v6, %C1 : _
+  %v8 = llvm.and %v7, %C1 : _
+  %v9 = llvm.and %v8, %C1 : _
+  %v10 = llvm.and %v9, %C1 : _
+  llvm.return %v10 : _
 }]
 
 def and_sequence_10_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z, %C1) : (_, _) -> (_)
-  "llvm.return" (%v1) : (_) -> ()
+  %v1 = llvm.and %Z,  %C1 : _
+  llvm.return %v1 : _
 }]
 
 theorem and_sequence_10_eq (w : Nat) :
@@ -61,27 +62,27 @@ theorem and_sequence_10_eq (w : Nat) :
 def and_sequence_15_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z,%C1) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%C1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%C1) : (_, _) -> (_)
-  %v4 = "llvm.and" (%v3,%C1) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v4,%C1) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v5,%C1) : (_, _) -> (_)
-  %v7 = "llvm.and" (%v6,%C1) : (_, _) -> (_)
-  %v8 = "llvm.and" (%v7,%C1) : (_, _) -> (_)
-  %v9 = "llvm.and" (%v8,%C1) : (_, _) -> (_)
-  %v10 = "llvm.and" (%v9,%C1) : (_, _) -> (_)
-  %v11 = "llvm.and" (%v10,%C1) : (_, _) -> (_)
-  %v12 = "llvm.and" (%v11,%C1) : (_, _) -> (_)
-  %v13 = "llvm.and" (%v12,%C1) : (_, _) -> (_)
-  "llvm.return" (%v13) : (_) -> ()
+  %v1 = llvm.and %Z, %C1 : _
+  %v2 = llvm.and %v1, %C1 : _
+  %v3 = llvm.and %v2, %C1 : _
+  %v4 = llvm.and %v3, %C1 : _
+  %v5 = llvm.and %v4, %C1 : _
+  %v6 = llvm.and %v5, %C1 : _
+  %v7 = llvm.and %v6, %C1 : _
+  %v8 = llvm.and %v7, %C1 : _
+  %v9 = llvm.and %v8, %C1 : _
+  %v10 = llvm.and %v9, %C1 : _
+  %v11 = llvm.and %v10, %C1 : _
+  %v12 = llvm.and %v11, %C1 : _
+  %v13 = llvm.and %v12, %C1 : _
+  llvm.return %v13 : _
 }]
 
 def and_sequence_15_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z, %C1) : (_, _) -> (_)
-  "llvm.return" (%v1) : (_) -> ()
+  %v1 = llvm.and %Z,  %C1 : _
+  llvm.return %v1 : _
 }]
 
 theorem and_sequence_15_eq (w : Nat) :
@@ -97,34 +98,34 @@ set_option maxHeartbeats 500000 in
 def and_sequence_20_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z,%C1) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%C1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%C1) : (_, _) -> (_)
-  %v4 = "llvm.and" (%v3,%C1) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v4,%C1) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v5,%C1) : (_, _) -> (_)
-  %v7 = "llvm.and" (%v6,%C1) : (_, _) -> (_)
-  %v8 = "llvm.and" (%v7,%C1) : (_, _) -> (_)
-  %v9 = "llvm.and" (%v8,%C1) : (_, _) -> (_)
-  %v10 = "llvm.and" (%v9,%C1) : (_, _) -> (_)
-  %v11 = "llvm.and" (%v10,%C1) : (_, _) -> (_)
-  %v12 = "llvm.and" (%v11,%C1) : (_, _) -> (_)
-  %v13 = "llvm.and" (%v12,%C1) : (_, _) -> (_)
-  %v14 = "llvm.and" (%v13,%C1) : (_, _) -> (_)
-  %v15 = "llvm.and" (%v14,%C1) : (_, _) -> (_)
-  %v16 = "llvm.and" (%v15,%C1) : (_, _) -> (_)
-  %v17 = "llvm.and" (%v16,%C1) : (_, _) -> (_)
-  %v18 = "llvm.and" (%v17,%C1) : (_, _) -> (_)
-  %v19 = "llvm.and" (%v18,%C1) : (_, _) -> (_)
-  %v20 = "llvm.and" (%v19,%C1) : (_, _) -> (_)
-  "llvm.return" (%v20) : (_) -> ()
+  %v1 = llvm.and %Z, %C1 : _
+  %v2 = llvm.and %v1, %C1 : _
+  %v3 = llvm.and %v2, %C1 : _
+  %v4 = llvm.and %v3, %C1 : _
+  %v5 = llvm.and %v4, %C1 : _
+  %v6 = llvm.and %v5, %C1 : _
+  %v7 = llvm.and %v6, %C1 : _
+  %v8 = llvm.and %v7, %C1 : _
+  %v9 = llvm.and %v8, %C1 : _
+  %v10 = llvm.and %v9, %C1 : _
+  %v11 = llvm.and %v10, %C1 : _
+  %v12 = llvm.and %v11, %C1 : _
+  %v13 = llvm.and %v12, %C1 : _
+  %v14 = llvm.and %v13, %C1 : _
+  %v15 = llvm.and %v14, %C1 : _
+  %v16 = llvm.and %v15, %C1 : _
+  %v17 = llvm.and %v16, %C1 : _
+  %v18 = llvm.and %v17, %C1 : _
+  %v19 = llvm.and %v18, %C1 : _
+  %v20 = llvm.and %v19, %C1 : _
+  llvm.return %v20 : _
 }]
 
 def and_sequence_20_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z, %C1) : (_, _) -> (_)
-  "llvm.return" (%v1) : (_) -> ()
+  %v1 = llvm.and %Z,  %C1 : _
+  llvm.return %v1 : _
 }]
 
 theorem and_sequence_20_eq (w : Nat) :
@@ -140,44 +141,44 @@ set_option maxHeartbeats 1700000 in
 def and_sequence_30_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z,%C1) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%C1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%C1) : (_, _) -> (_)
-  %v4 = "llvm.and" (%v3,%C1) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v4,%C1) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v5,%C1) : (_, _) -> (_)
-  %v7 = "llvm.and" (%v6,%C1) : (_, _) -> (_)
-  %v8 = "llvm.and" (%v7,%C1) : (_, _) -> (_)
-  %v9 = "llvm.and" (%v8,%C1) : (_, _) -> (_)
-  %v10 = "llvm.and" (%v9,%C1) : (_, _) -> (_)
-  %v11 = "llvm.and" (%v10,%C1) : (_, _) -> (_)
-  %v12 = "llvm.and" (%v11,%C1) : (_, _) -> (_)
-  %v13 = "llvm.and" (%v12,%C1) : (_, _) -> (_)
-  %v14 = "llvm.and" (%v13,%C1) : (_, _) -> (_)
-  %v15 = "llvm.and" (%v14,%C1) : (_, _) -> (_)
-  %v16 = "llvm.and" (%v15,%C1) : (_, _) -> (_)
-  %v17 = "llvm.and" (%v16,%C1) : (_, _) -> (_)
-  %v18 = "llvm.and" (%v17,%C1) : (_, _) -> (_)
-  %v19 = "llvm.and" (%v18,%C1) : (_, _) -> (_)
-  %v20 = "llvm.and" (%v19,%C1) : (_, _) -> (_)
-  %v21 = "llvm.and" (%v20,%C1) : (_, _) -> (_)
-  %v22 = "llvm.and" (%v21,%C1) : (_, _) -> (_)
-  %v23 = "llvm.and" (%v22,%C1) : (_, _) -> (_)
-  %v24 = "llvm.and" (%v23,%C1) : (_, _) -> (_)
-  %v25 = "llvm.and" (%v24,%C1) : (_, _) -> (_)
-  %v26 = "llvm.and" (%v25,%C1) : (_, _) -> (_)
-  %v27 = "llvm.and" (%v26,%C1) : (_, _) -> (_)
-  %v28 = "llvm.and" (%v27,%C1) : (_, _) -> (_)
-  %v29 = "llvm.and" (%v28,%C1) : (_, _) -> (_)
-  %v30 = "llvm.and" (%v29,%C1) : (_, _) -> (_)
-  "llvm.return" (%v30) : (_) -> ()
+  %v1 = llvm.and %Z, %C1 : _
+  %v2 = llvm.and %v1, %C1 : _
+  %v3 = llvm.and %v2, %C1 : _
+  %v4 = llvm.and %v3, %C1 : _
+  %v5 = llvm.and %v4, %C1 : _
+  %v6 = llvm.and %v5, %C1 : _
+  %v7 = llvm.and %v6, %C1 : _
+  %v8 = llvm.and %v7, %C1 : _
+  %v9 = llvm.and %v8, %C1 : _
+  %v10 = llvm.and %v9, %C1 : _
+  %v11 = llvm.and %v10, %C1 : _
+  %v12 = llvm.and %v11, %C1 : _
+  %v13 = llvm.and %v12, %C1 : _
+  %v14 = llvm.and %v13, %C1 : _
+  %v15 = llvm.and %v14, %C1 : _
+  %v16 = llvm.and %v15, %C1 : _
+  %v17 = llvm.and %v16, %C1 : _
+  %v18 = llvm.and %v17, %C1 : _
+  %v19 = llvm.and %v18, %C1 : _
+  %v20 = llvm.and %v19, %C1 : _
+  %v21 = llvm.and %v20, %C1 : _
+  %v22 = llvm.and %v21, %C1 : _
+  %v23 = llvm.and %v22, %C1 : _
+  %v24 = llvm.and %v23, %C1 : _
+  %v25 = llvm.and %v24, %C1 : _
+  %v26 = llvm.and %v25, %C1 : _
+  %v27 = llvm.and %v26, %C1 : _
+  %v28 = llvm.and %v27, %C1 : _
+  %v29 = llvm.and %v28, %C1 : _
+  %v30 = llvm.and %v29, %C1 : _
+  llvm.return %v30 : _
 }]
 
 def and_sequence_30_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z, %C1) : (_, _) -> (_)
-  "llvm.return" (%v1) : (_) -> ()
+  %v1 = llvm.and %Z,  %C1 : _
+  llvm.return %v1 : _
 }]
 
 theorem and_sequence_30_eq (w : Nat) :
@@ -194,54 +195,54 @@ set_option maxRecDepth 1500 in
 def and_sequence_40_lhs (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z,%C1) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%C1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%C1) : (_, _) -> (_)
-  %v4 = "llvm.and" (%v3,%C1) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v4,%C1) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v5,%C1) : (_, _) -> (_)
-  %v7 = "llvm.and" (%v6,%C1) : (_, _) -> (_)
-  %v8 = "llvm.and" (%v7,%C1) : (_, _) -> (_)
-  %v9 = "llvm.and" (%v8,%C1) : (_, _) -> (_)
-  %v10 = "llvm.and" (%v9,%C1) : (_, _) -> (_)
-  %v11 = "llvm.and" (%v10,%C1) : (_, _) -> (_)
-  %v12 = "llvm.and" (%v11,%C1) : (_, _) -> (_)
-  %v13 = "llvm.and" (%v12,%C1) : (_, _) -> (_)
-  %v14 = "llvm.and" (%v13,%C1) : (_, _) -> (_)
-  %v15 = "llvm.and" (%v14,%C1) : (_, _) -> (_)
-  %v16 = "llvm.and" (%v15,%C1) : (_, _) -> (_)
-  %v17 = "llvm.and" (%v16,%C1) : (_, _) -> (_)
-  %v18 = "llvm.and" (%v17,%C1) : (_, _) -> (_)
-  %v19 = "llvm.and" (%v18,%C1) : (_, _) -> (_)
-  %v20 = "llvm.and" (%v19,%C1) : (_, _) -> (_)
-  %v21 = "llvm.and" (%v20,%C1) : (_, _) -> (_)
-  %v22 = "llvm.and" (%v21,%C1) : (_, _) -> (_)
-  %v23 = "llvm.and" (%v22,%C1) : (_, _) -> (_)
-  %v24 = "llvm.and" (%v23,%C1) : (_, _) -> (_)
-  %v25 = "llvm.and" (%v24,%C1) : (_, _) -> (_)
-  %v26 = "llvm.and" (%v25,%C1) : (_, _) -> (_)
-  %v27 = "llvm.and" (%v26,%C1) : (_, _) -> (_)
-  %v28 = "llvm.and" (%v27,%C1) : (_, _) -> (_)
-  %v29 = "llvm.and" (%v28,%C1) : (_, _) -> (_)
-  %v30 = "llvm.and" (%v29,%C1) : (_, _) -> (_)
-  %v31 = "llvm.and" (%v30,%C1) : (_, _) -> (_)
-  %v32 = "llvm.and" (%v31,%C1) : (_, _) -> (_)
-  %v33 = "llvm.and" (%v32,%C1) : (_, _) -> (_)
-  %v34 = "llvm.and" (%v33,%C1) : (_, _) -> (_)
-  %v35 = "llvm.and" (%v34,%C1) : (_, _) -> (_)
-  %v36 = "llvm.and" (%v35,%C1) : (_, _) -> (_)
-  %v37 = "llvm.and" (%v36,%C1) : (_, _) -> (_)
-  %v38 = "llvm.and" (%v37,%C1) : (_, _) -> (_)
-  %v39 = "llvm.and" (%v38,%C1) : (_, _) -> (_)
-  %v40 = "llvm.and" (%v39,%C1) : (_, _) -> (_)
-  "llvm.return" (%v40) : (_) -> ()
+  %v1 = llvm.and %Z, %C1 : _
+  %v2 = llvm.and %v1, %C1 : _
+  %v3 = llvm.and %v2, %C1 : _
+  %v4 = llvm.and %v3, %C1 : _
+  %v5 = llvm.and %v4, %C1 : _
+  %v6 = llvm.and %v5, %C1 : _
+  %v7 = llvm.and %v6, %C1 : _
+  %v8 = llvm.and %v7, %C1 : _
+  %v9 = llvm.and %v8, %C1 : _
+  %v10 = llvm.and %v9, %C1 : _
+  %v11 = llvm.and %v10, %C1 : _
+  %v12 = llvm.and %v11, %C1 : _
+  %v13 = llvm.and %v12, %C1 : _
+  %v14 = llvm.and %v13, %C1 : _
+  %v15 = llvm.and %v14, %C1 : _
+  %v16 = llvm.and %v15, %C1 : _
+  %v17 = llvm.and %v16, %C1 : _
+  %v18 = llvm.and %v17, %C1 : _
+  %v19 = llvm.and %v18, %C1 : _
+  %v20 = llvm.and %v19, %C1 : _
+  %v21 = llvm.and %v20, %C1 : _
+  %v22 = llvm.and %v21, %C1 : _
+  %v23 = llvm.and %v22, %C1 : _
+  %v24 = llvm.and %v23, %C1 : _
+  %v25 = llvm.and %v24, %C1 : _
+  %v26 = llvm.and %v25, %C1 : _
+  %v27 = llvm.and %v26, %C1 : _
+  %v28 = llvm.and %v27, %C1 : _
+  %v29 = llvm.and %v28, %C1 : _
+  %v30 = llvm.and %v29, %C1 : _
+  %v31 = llvm.and %v30, %C1 : _
+  %v32 = llvm.and %v31, %C1 : _
+  %v33 = llvm.and %v32, %C1 : _
+  %v34 = llvm.and %v33, %C1 : _
+  %v35 = llvm.and %v34, %C1 : _
+  %v36 = llvm.and %v35, %C1 : _
+  %v37 = llvm.and %v36, %C1 : _
+  %v38 = llvm.and %v37, %C1 : _
+  %v39 = llvm.and %v38, %C1 : _
+  %v40 = llvm.and %v39, %C1 : _
+  llvm.return %v40 : _
 }]
 
 def and_sequence_40_rhs (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _):
-  %v1 = "llvm.and" (%Z, %C1) : (_, _) -> (_)
-  "llvm.return" (%v1) : (_) -> ()
+  %v1 = llvm.and %Z,  %C1 : _
+  llvm.return %v1 : _
 }]
 
 set_option maxHeartbeats 800000 in

--- a/SSA/Projects/InstCombine/Tactic.lean
+++ b/SSA/Projects/InstCombine/Tactic.lean
@@ -9,7 +9,6 @@ import Mathlib.Tactic
 import SSA.Core.ErasedContext
 import SSA.Core.Tactic
 import Batteries.Data.BitVec
-import Mathlib.Data.BitVec.Lemmas
 
 open MLIR AST
 

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -3,7 +3,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Tactic.Ring
 import Batteries.Data.BitVec
-import Mathlib.Data.BitVec.Lemmas
 import SSA.Projects.InstCombine.ForLean
 
 import SSA.Projects.InstCombine.LLVM.EDSL

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -243,16 +243,16 @@ set_option ssa.alive_icom_reduce true in
 def one_inst_macro (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = "llvm.not" (%arg0) : (_) -> (_)
-    "llvm.return" (%0) : (_) -> ()
+    %0 = llvm.not %arg0 : _
+    llvm.return %0 : _
   }]
 
 set_option ssa.alive_icom_reduce false in
 def one_inst_macro_noreduce (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = "llvm.not" (%arg0) : (_) -> (_)
-    "llvm.return" (%0) : (_) -> ()
+    %0 = llvm.not %arg0 : _
+    llvm.return %0 : _
   }]
 
 def one_inst_com (w : ℕ) :
@@ -290,18 +290,18 @@ set_option ssa.alive_icom_reduce true in
 def two_inst_macro (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = "llvm.not" (%arg0) : (_) -> (_)
-    %1 = "llvm.not" (%arg0) : (_) -> (_)
-    "llvm.return" (%0) : (_) -> ()
+    %0 = llvm.not %arg0 : _
+    %1 = llvm.not %arg0 : _
+    llvm.return %0 : _
   }]
 
 set_option ssa.alive_icom_reduce false in
 def two_inst_macro_noreduce (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = "llvm.not" (%arg0) : (_) -> (_)
-    %1 = "llvm.not" (%arg0) : (_) -> (_)
-    "llvm.return" (%0) : (_) -> ()
+    %0 = llvm.not %arg0 : _
+    %1 = llvm.not %arg0 : _
+    llvm.return %0 : _
   }]
 
 def two_inst_com (w : ℕ) :
@@ -339,20 +339,20 @@ def two_inst_macro_noreduce_proof (w : Nat) :
 def three_inst_macro (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = "llvm.not" (%arg0) : (_) -> (_)
-    %1 = "llvm.not" (%0) : (_) -> (_)
-    %2 = "llvm.not" (%1) : (_) -> (_)
-    "llvm.return" (%2) : (_) -> ()
+    %0 = llvm.not %arg0 : _
+    %1 = llvm.not %0 : _
+    %2 = llvm.not %1 : _
+    llvm.return %2 : _
   }]
 
 set_option ssa.alive_icom_reduce false in
 def three_inst_macro_noreduce (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = "llvm.not" (%arg0) : (_) -> (_)
-    %1 = "llvm.not" (%0) : (_) -> (_)
-    %2 = "llvm.not" (%1) : (_) -> (_)
-    "llvm.return" (%2) : (_) -> ()
+    %0 = llvm.not %arg0 : _
+    %1 = llvm.not %0 : _
+    %2 = llvm.not %1 : _
+    llvm.return %2 : _
   }]
 
 def three_inst_com (w : ℕ) :
@@ -393,16 +393,16 @@ set_option ssa.alive_icom_reduce true in
 def one_inst_concrete_macro :=
   [alive_icom ()|{
   ^bb0(%arg0: i1):
-    %0 = "llvm.not" (%arg0) : (i1) -> (i1)
-    "llvm.return" (%0) : (i1) -> ()
+    %0 = llvm.not %arg0 : i1
+    llvm.return %0 : i1
   }]
 
 set_option ssa.alive_icom_reduce false in
 def one_inst_concrete_macro_noreduce :=
   [alive_icom ()|{
   ^bb0(%arg0: i1):
-    %0 = "llvm.not" (%arg0) : (i1) -> (i1)
-    "llvm.return" (%0) : (i1) -> ()
+    %0 = llvm.not %arg0 : i1
+    llvm.return %0 : i1
   }]
 
 def one_inst_concrete_com :
@@ -440,18 +440,18 @@ set_option ssa.alive_icom_reduce true in
 def two_inst_concrete_macro :=
   [alive_icom ()|{
   ^bb0(%arg0: i1):
-    %0 = "llvm.not" (%arg0) : (i1) -> (i1)
-    %1 = "llvm.not" (%arg0) : (i1) -> (i1)
-    "llvm.return" (%0) : (i1) -> ()
+    %0 = llvm.not %arg0 : i1
+    %1 = llvm.not %arg0 : i1
+    llvm.return %0 : i1
   }]
 
 set_option ssa.alive_icom_reduce false in
 def two_inst_concrete_macro_noreduce :=
   [alive_icom ()|{
   ^bb0(%arg0: i1):
-    %0 = "llvm.not" (%arg0) : (i1) -> (i1)
-    %1 = "llvm.not" (%arg0) : (i1) -> (i1)
-    "llvm.return" (%0) : (i1) -> ()
+    %0 = llvm.not %arg0 : i1
+    %1 = llvm.not %arg0 : i1
+    llvm.return %0 : i1
   }]
 
 def two_inst_concrete_com (w : ℕ) :
@@ -490,20 +490,20 @@ set_option ssa.alive_icom_reduce true in
 def three_inst_concrete_macro :=
   [alive_icom ()|{
   ^bb0(%arg0: i1):
-    %0 = "llvm.not" (%arg0) : (i1) -> (i1)
-    %1 = "llvm.not" (%0) : (i1) -> (i1)
-    %2 = "llvm.not" (%1) : (i1) -> (i1)
-    "llvm.return" (%2) : (i1) -> ()
+    %0 = llvm.not %arg0 : i1
+    %1 = llvm.not %0 : i1
+    %2 = llvm.not %1 : i1
+    llvm.return %2 : i1
   }]
 
 set_option ssa.alive_icom_reduce false in
 def three_inst_concrete_macro_noreduce :=
   [alive_icom ()|{
   ^bb0(%arg0: i1):
-    %0 = "llvm.not" (%arg0) : (i1) -> (i1)
-    %1 = "llvm.not" (%0) : (i1) -> (i1)
-    %2 = "llvm.not" (%1) : (i1) -> (i1)
-    "llvm.return" (%2) : (i1) -> ()
+    %0 = llvm.not %arg0 : i1
+    %1 = llvm.not %0 : i1
+    %2 = llvm.not %1 : i1
+    llvm.return %2 : i1
   }]
 
 def three_inst_concrete_com :
@@ -544,9 +544,9 @@ set_option ssa.alive_icom_reduce false in
 def two_ne_macro_noreduce (w : Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _, %arg1: _):
-    %0 = "llvm.icmp.ne" (%arg0, %arg1) : (_, _) -> (i1)
-    %1 = "llvm.icmp.ne" (%arg0, %arg1) : (_, _) -> (i1)
-    "llvm.return" (%1) : (i1) -> ()
+    %0 = llvm.icmp.ne %arg0,  %arg1 : _
+    %1 = llvm.icmp.ne %arg0,  %arg1 : _
+    llvm.return %1 : i1
   }]
 
 def two_ne_stmt (a b : LLVM.IntW w) :
@@ -570,11 +570,11 @@ def constant_macro (w : Nat) :=
     %2 = "llvm.mlir.constant" () { value = 0 : _ } : () -> (_)
     %3 = "llvm.mlir.constant" () { value = -1 : _ } : () -> (_)
     %4 = "llvm.mlir.constant" () { value = -2 : _ } : () -> (_)
-    %5 = "llvm.add" (%0, %1) : (_, _) -> (_)
-    %6 = "llvm.add" (%5, %2) : (_, _) -> (_)
-    %7 = "llvm.add" (%6, %3) : (_, _) -> (_)
-    %8 = "llvm.add" (%7, %4) : (_, _) -> (_)
-    "llvm.return" (%8) : (_) -> ()
+    %5 = llvm.add %0,  %1 : _
+    %6 = llvm.add %5,  %2 : _
+    %7 = llvm.add %6,  %3 : _
+    %8 = llvm.add %7,  %4 : _
+    llvm.return %8 : _
   }]
 
 set_option ssa.alive_icom_reduce false in
@@ -586,11 +586,11 @@ def constant_macro_noreduce (w : Nat) :=
     %2 = "llvm.mlir.constant" () { value = 0 : _ } : () -> (_)
     %3 = "llvm.mlir.constant" () { value = -1 : _ } : () -> (_)
     %4 = "llvm.mlir.constant" () { value = -2 : _ } : () -> (_)
-    %5 = "llvm.add" (%0, %1) : (_, _) -> (_)
-    %6 = "llvm.add" (%5, %2) : (_, _) -> (_)
-    %7 = "llvm.add" (%6, %3) : (_, _) -> (_)
-    %8 = "llvm.add" (%7, %4) : (_, _) -> (_)
-    "llvm.return" (%8) : (_) -> ()
+    %5 = llvm.add %0,  %1 : _
+    %6 = llvm.add %5,  %2 : _
+    %7 = llvm.add %6,  %3 : _
+    %8 = llvm.add %7,  %4 : _
+    llvm.return %8 : _
   }]
 
 def constant_stmt :

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -243,16 +243,16 @@ set_option ssa.alive_icom_reduce true in
 def one_inst_macro (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = llvm.not %arg0 : _
-    llvm.return %0 : _
+    %0 = llvm.not %arg0
+    llvm.return %0
   }]
 
 set_option ssa.alive_icom_reduce false in
 def one_inst_macro_noreduce (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = llvm.not %arg0 : _
-    llvm.return %0 : _
+    %0 = llvm.not %arg0
+    llvm.return %0
   }]
 
 def one_inst_com (w : ℕ) :
@@ -290,18 +290,18 @@ set_option ssa.alive_icom_reduce true in
 def two_inst_macro (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = llvm.not %arg0 : _
-    %1 = llvm.not %arg0 : _
-    llvm.return %0 : _
+    %0 = llvm.not %arg0
+    %1 = llvm.not %arg0
+    llvm.return %0
   }]
 
 set_option ssa.alive_icom_reduce false in
 def two_inst_macro_noreduce (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = llvm.not %arg0 : _
-    %1 = llvm.not %arg0 : _
-    llvm.return %0 : _
+    %0 = llvm.not %arg0
+    %1 = llvm.not %arg0
+    llvm.return %0
   }]
 
 def two_inst_com (w : ℕ) :
@@ -339,20 +339,20 @@ def two_inst_macro_noreduce_proof (w : Nat) :
 def three_inst_macro (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = llvm.not %arg0 : _
-    %1 = llvm.not %0 : _
-    %2 = llvm.not %1 : _
-    llvm.return %2 : _
+    %0 = llvm.not %arg0
+    %1 = llvm.not %0
+    %2 = llvm.not %1
+    llvm.return %2
   }]
 
 set_option ssa.alive_icom_reduce false in
 def three_inst_macro_noreduce (w: Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _):
-    %0 = llvm.not %arg0 : _
-    %1 = llvm.not %0 : _
-    %2 = llvm.not %1 : _
-    llvm.return %2 : _
+    %0 = llvm.not %arg0
+    %1 = llvm.not %0
+    %2 = llvm.not %1
+    llvm.return %2
   }]
 
 def three_inst_com (w : ℕ) :
@@ -544,8 +544,8 @@ set_option ssa.alive_icom_reduce false in
 def two_ne_macro_noreduce (w : Nat) :=
   [alive_icom (w)|{
   ^bb0(%arg0: _, %arg1: _):
-    %0 = llvm.icmp.ne %arg0,  %arg1 : _
-    %1 = llvm.icmp.ne %arg0,  %arg1 : _
+    %0 = llvm.icmp.ne %arg0,  %arg1
+    %1 = llvm.icmp.ne %arg0,  %arg1
     llvm.return %1 : i1
   }]
 
@@ -570,11 +570,11 @@ def constant_macro (w : Nat) :=
     %2 = "llvm.mlir.constant" () { value = 0 : _ } : () -> (_)
     %3 = "llvm.mlir.constant" () { value = -1 : _ } : () -> (_)
     %4 = "llvm.mlir.constant" () { value = -2 : _ } : () -> (_)
-    %5 = llvm.add %0,  %1 : _
-    %6 = llvm.add %5,  %2 : _
-    %7 = llvm.add %6,  %3 : _
-    %8 = llvm.add %7,  %4 : _
-    llvm.return %8 : _
+    %5 = llvm.add %0,  %1
+    %6 = llvm.add %5,  %2
+    %7 = llvm.add %6,  %3
+    %8 = llvm.add %7,  %4
+    llvm.return %8
   }]
 
 set_option ssa.alive_icom_reduce false in
@@ -586,11 +586,11 @@ def constant_macro_noreduce (w : Nat) :=
     %2 = "llvm.mlir.constant" () { value = 0 : _ } : () -> (_)
     %3 = "llvm.mlir.constant" () { value = -1 : _ } : () -> (_)
     %4 = "llvm.mlir.constant" () { value = -2 : _ } : () -> (_)
-    %5 = llvm.add %0,  %1 : _
-    %6 = llvm.add %5,  %2 : _
-    %7 = llvm.add %6,  %3 : _
-    %8 = llvm.add %7,  %4 : _
-    llvm.return %8 : _
+    %5 = llvm.add %0,  %1
+    %6 = llvm.add %5,  %2
+    %7 = llvm.add %6,  %3
+    %8 = llvm.add %7,  %4
+    llvm.return %8
   }]
 
 def constant_stmt :

--- a/SSA/Projects/InstCombine/TestLLVMOps.lean
+++ b/SSA/Projects/InstCombine/TestLLVMOps.lean
@@ -1,7 +1,7 @@
 /-
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import SSA.Projects.InstCombine.LLVM.EDSL
+import SSA.Projects.InstCombine.LLVM.PrettyEDSL
 import SSA.Projects.InstCombine.LLVM.CLITests
 
 open MLIR AST
@@ -14,193 +14,193 @@ open Ctxt (Var)
 deftest test_and :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.and" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.and %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_or :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.or" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.or %X, %Y : i4
+  llvm.return %r : i4
 }
 
 -- don't use this one since not in LLVM
 --deftest test_not :=
 --{
 --^bb0(%X : i4):
---  %r = "llvm.not" (%X) : (i4) -> (i4)
---  "llvm.return" (%r) : (i4) -> ()
+--  %r = llvm.not %X : i4
+--  llvm.return %r : i4
 --}
 
 deftest test_xor :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.xor" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.xor %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_shl :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.shl" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.shl %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_lshr :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.lshr" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.lshr %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_ashr :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.ashr" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.ashr %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_urem :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.urem" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.urem %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_srem :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.srem" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.srem %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_select :=
 {
 ^bb0(%X : i1, %Y : i4, %Z : i4):
-  %r = "llvm.select" (%X, %Y, %Z) : (i1, i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.select %X,  %Y, %Z : i4
+  llvm.return %r : i4
 }
 
 deftest test_add :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.add" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.add %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_sub :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.sub" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.sub %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_mul :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.mul" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.mul %X, %Y : i4
+  llvm.return %r : i4
 }
 
 -- don't use this one since not in LLVM
 -- deftest test_neg :=
 -- {
 -- ^bb0(%X : i4):
---   %r = "llvm.neg" (%X) : (i4) -> (i4)
---   "llvm.return" (%r) : (i4) -> ()
+--   %r = llvm.neg %X : i4
+--   llvm.return %r : i4
 -- }
 
 -- don't use this one since not in LLVM
 -- deftest test_copy :=
 -- {
 -- ^bb0(%X : i4):
---   %r = "llvm.copy" (%X) : (i4) -> (i4)
---   "llvm.return" (%r) : (i4) -> ()
+--   %r = llvm.copy %X : i4
+--   llvm.return %r : i4
 -- }
 
 deftest test_udiv :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.udiv" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.udiv %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_sdiv :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.sdiv" (%X,%Y) : (i4, i4) -> (i4)
-  "llvm.return" (%r) : (i4) -> ()
+  %r = llvm.sdiv %X, %Y : i4
+  llvm.return %r : i4
 }
 
 deftest test_icmp_eq :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.eq" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.eq %X, %Y : i4
+  llvm.return %r : i1
 }
 
 deftest test_icmp_ne :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.ne" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.ne %X, %Y : i4
+  llvm.return %r : i1
 }
 
 deftest test_icmp_ult :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.ult" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.ult %X, %Y : i4
+  llvm.return %r : i1
 }
 
 deftest test_icmp_ugt :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.ugt" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.ugt %X, %Y : i4
+  llvm.return %r : i1
 }
 
 
 deftest test_icmp_slt :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.slt" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.slt %X, %Y : i4
+  llvm.return %r : i1
 }
 
 deftest test_icmp_sgt :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.sgt" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.sgt %X, %Y : i4
+  llvm.return %r : i1
 }
 
 deftest test_icmp_ule :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.ule" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.ule %X, %Y : i4
+  llvm.return %r : i1
 }
 
 deftest test_icmp_uge :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.uge" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.uge %X, %Y : i4
+  llvm.return %r : i1
 }
 
 
 deftest test_icmp_sle :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.sle" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.sle %X, %Y : i4
+  llvm.return %r : i1
 }
 
 deftest test_icmp_sge :=
 {
 ^bb0(%X : i4, %Y : i4):
-  %r = "llvm.icmp.sge" (%X,%Y) : (i4, i4) -> (i1)
-  "llvm.return" (%r) : (i1) -> ()
+  %r = llvm.icmp.sge %X, %Y : i4
+  llvm.return %r : i1
 }

--- a/SSA/Projects/InstCombine/update_alive_statements.py
+++ b/SSA/Projects/InstCombine/update_alive_statements.py
@@ -17,7 +17,6 @@ import SSA.Projects.InstCombine.ForStd
 import SSA.Projects.InstCombine.ForMathlib
 import SSA.Projects.InstCombine.LLVM.Semantics
 import Batteries.Data.BitVec
-import Mathlib.Data.BitVec.Lemmas
 
 open LLVM
 open BitVec

--- a/SSA/Projects/PaperExamples/PaperExamples.lean
+++ b/SSA/Projects/PaperExamples/PaperExamples.lean
@@ -12,7 +12,6 @@ import SSA.Core.MLIRSyntax.EDSL
 import Batteries.Data.BitVec
 import Mathlib.Data.BitVec.Lemmas
 import Mathlib.Tactic.Ring
--- import Mathlib.Data.StdBitVec.Lemmas
 
 set_option pp.proofs false
 set_option pp.proofs.withType false


### PR DESCRIPTION
We convert all manually written users of the LLVM syntax to the pretty syntax but leave the AliveAutogenerated.lean for a later conversion to allow the auto-generation to be updated together with AliveAutoGenerated.lean.

We also add support for llvm.icmp, which requires separate macro rules to support its i1 return type.