### PR TITLE
feat: move AliveAutogenerated to concise syntax - sed part

### DIFF
--- a/SSA/Projects/InstCombine/AliveAutoGenerated.lean
+++ b/SSA/Projects/InstCombine/AliveAutoGenerated.lean
@@ -3149,7 +3149,7 @@ def alive_Select_858_src  (w : Nat)   :=
 ^bb0(%a : i1, %b : i1):
   %v1 = llvm.mlir.constant -1 :  i1
   %v2 = llvm.xor %a, %v1 : i1
-  %v3 = llvm.select %a,%v2, %b : i1, i1
+  %v3 = llvm.select %a,%v2, %b : i1
   llvm.return %v3 : i1
 }]
 
@@ -3183,7 +3183,7 @@ def alive_Select_859'_src  (w : Nat)   :=
 ^bb0(%a : i1, %b : i1):
   %v1 = llvm.mlir.constant -1 :  i1
   %v2 = llvm.xor %a, %v1 : i1
-  %v3 = llvm.select %a,%b, %v2 : i1, i1
+  %v3 = llvm.select %a,%b, %v2 : i1
   llvm.return %v3 : i1
 }]
 
@@ -3195,7 +3195,7 @@ def alive_Select_859'_tgt  (w : Nat)  :=
   %v3 = llvm.or %v2, %b
   llvm.return %v3
 }]
-theorem alive_Select_859'  (w : Nat)   : alive_Select_859'_src w  ⊑ alive_Select_859'_tgt 1  := by
+theorem alive_Select_859'  (w : Nat)   : alive_Select_859'_src w ⊑ alive_Select_859'_tgt 1  := by
   unfold alive_Select_859'_src alive_Select_859'_tgt
   simp_alive_peephole
   apply bitvec_Select_859'
@@ -3213,7 +3213,7 @@ def alive_Select_1100_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.mlir.constant 1 :  i1
-  %v2 = llvm.select %v1,%X, %Y : i1, _
+  %v2 = llvm.select %v1, %X, %Y
   llvm.return %v2
 }]
 
@@ -3242,7 +3242,7 @@ def alive_Select_1105_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.mlir.constant 0 :  i1
-  %v2 = llvm.select %v1,%X, %Y : i1, _
+  %v2 = llvm.select %v1,%X, %Y
   llvm.return %v2
 }]
 

--- a/SSA/Projects/InstCombine/AliveAutoGenerated.lean
+++ b/SSA/Projects/InstCombine/AliveAutoGenerated.lean
@@ -2,7 +2,7 @@
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
-import SSA.Projects.InstCombine.LLVM.EDSL
+import SSA.Projects.InstCombine.LLVM.PrettyEDSL
 import SSA.Projects.InstCombine.AliveStatements
 import SSA.Projects.InstCombine.Refinement
 import SSA.Projects.InstCombine.Tactic
@@ -37,25 +37,25 @@ set_option linter.deprecated false
 def alive_AddSub_1043_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _, %RHS : _):
-  %v1 = "llvm.and" (%Z,%C1) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%v1,%C1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = 1 : _ } :() -> (_)
-  %v4 = "llvm.add" (%v2,%v3) : (_, _) -> (_)
-  %v5 = "llvm.add" (%v4,%RHS) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.and %Z, %C1
+  %v2 = llvm.xor %v1, %C1
+  %v3 = llvm.mlir.constant 1
+  %v4 = llvm.add %v2, %v3
+  %v5 = llvm.add %v4, %RHS
+  llvm.return %v5
 }]
 
 def alive_AddSub_1043_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%C1 : _, %Z : _, %RHS : _):
-  %v1 = "llvm.not" (%C1) : (_) -> (_)
-  %v2 = "llvm.or" (%Z,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%Z,%C1) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%v3,%C1) : (_, _) -> (_)
-  %v5 = "llvm.mlir.constant" () { value = 1 : _ } :() -> (_)
-  %v6 = "llvm.add" (%v4,%v5) : (_, _) -> (_)
-  %v7 = "llvm.sub" (%RHS,%v2) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.not %C1
+  %v2 = llvm.or %Z, %v1
+  %v3 = llvm.and %Z, %C1
+  %v4 = llvm.xor %v3, %C1
+  %v5 = llvm.mlir.constant 1
+  %v6 = llvm.add %v4, %v5
+  %v7 = llvm.sub %RHS, %v2
+  llvm.return %v7
 }]
 theorem alive_AddSub_1043  (w : Nat)   : alive_AddSub_1043_src w  ⊑ alive_AddSub_1043_tgt w  := by
   unfold alive_AddSub_1043_src alive_AddSub_1043_tgt
@@ -75,15 +75,15 @@ theorem alive_AddSub_1043  (w : Nat)   : alive_AddSub_1043_src w  ⊑ alive_AddS
 def alive_AddSub_1152_src   :=
 [alive_icom ()| {
 ^bb0(%y : i1, %x : i1):
-  %v1 = "llvm.add" (%x,%y) : (i1, i1) -> (i1)
-  "llvm.return" (%v1) : (i1) -> ()
+  %v1 = llvm.add %x, %y : i1
+  llvm.return %v1 : i1
 }]
 
 def alive_AddSub_1152_tgt  :=
 [alive_icom ()| {
 ^bb0(%y : i1, %x : i1):
-  %v1 = "llvm.xor" (%x,%y) : (i1, i1) -> (i1)
-  "llvm.return" (%v1) : (i1) -> ()
+  %v1 = llvm.xor %x, %y : i1
+  llvm.return %v1 : i1
 }]
 theorem alive_AddSub_1152   : alive_AddSub_1152_src ⊑ alive_AddSub_1152_tgt := by
   unfold alive_AddSub_1152_src alive_AddSub_1152_tgt
@@ -103,16 +103,16 @@ theorem alive_AddSub_1152   : alive_AddSub_1152_src ⊑ alive_AddSub_1152_tgt :=
 def alive_AddSub_1156_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%b : _):
-  %v1 = "llvm.add" (%b,%b) : (_, _) -> (_)
-  "llvm.return" (%v1) : (_) -> ()
+  %v1 = llvm.add %b, %b
+  llvm.return %v1
 }]
 
 def alive_AddSub_1156_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%b : _):
-  %v1 = "llvm.mlir.constant" () { value = 1 : _ } :() -> (_)
-  %v2 = "llvm.shl" (%b,%v1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.mlir.constant 1
+  %v2 = llvm.shl %b, %v1
+  llvm.return %v2
 }]
 theorem alive_AddSub_1156  (w : Nat)   : alive_AddSub_1156_src w  ⊑ alive_AddSub_1156_tgt w  := by
   unfold alive_AddSub_1156_src alive_AddSub_1156_tgt
@@ -134,19 +134,19 @@ theorem alive_AddSub_1156  (w : Nat)   : alive_AddSub_1156_src w  ⊑ alive_AddS
 def alive_AddSub_1164_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%a) : (_, _) -> (_)
-  %v3 = "llvm.add" (%v2,%b) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %a
+  %v3 = llvm.add %v2, %b
+  llvm.return %v3
 }]
 
 def alive_AddSub_1164_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%a) : (_, _) -> (_)
-  %v3 = "llvm.sub" (%b,%a) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %a
+  %v3 = llvm.sub %b, %a
+  llvm.return %v3
 }]
 theorem alive_AddSub_1164  (w : Nat)   : alive_AddSub_1164_src w  ⊑ alive_AddSub_1164_tgt w  := by
   unfold alive_AddSub_1164_src alive_AddSub_1164_tgt
@@ -171,25 +171,25 @@ theorem alive_AddSub_1164  (w : Nat)   : alive_AddSub_1164_src w  ⊑ alive_AddS
 def alive_AddSub_1165_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%a) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v4 = "llvm.sub" (%v3,%b) : (_, _) -> (_)
-  %v5 = "llvm.add" (%v2,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %a
+  %v3 = llvm.mlir.constant 0
+  %v4 = llvm.sub %v3, %b
+  %v5 = llvm.add %v2, %v4
+  llvm.return %v5
 }]
 
 def alive_AddSub_1165_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.add" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v3 = "llvm.sub" (%v2,%a) : (_, _) -> (_)
-  %v4 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v5 = "llvm.sub" (%v4,%b) : (_, _) -> (_)
-  %v6 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v7 = "llvm.sub" (%v6,%v1) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.add %a, %b
+  %v2 = llvm.mlir.constant 0
+  %v3 = llvm.sub %v2, %a
+  %v4 = llvm.mlir.constant 0
+  %v5 = llvm.sub %v4, %b
+  %v6 = llvm.mlir.constant 0
+  %v7 = llvm.sub %v6, %v1
+  llvm.return %v7
 }]
 theorem alive_AddSub_1165  (w : Nat)   : alive_AddSub_1165_src w  ⊑ alive_AddSub_1165_tgt w  := by
   unfold alive_AddSub_1165_src alive_AddSub_1165_tgt
@@ -211,19 +211,19 @@ theorem alive_AddSub_1165  (w : Nat)   : alive_AddSub_1165_src w  ⊑ alive_AddS
 def alive_AddSub_1176_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%b) : (_, _) -> (_)
-  %v3 = "llvm.add" (%a,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %b
+  %v3 = llvm.add %a, %v2
+  llvm.return %v3
 }]
 
 def alive_AddSub_1176_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%b) : (_, _) -> (_)
-  %v3 = "llvm.sub" (%a,%b) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %b
+  %v3 = llvm.sub %a, %b
+  llvm.return %v3
 }]
 theorem alive_AddSub_1176  (w : Nat)   : alive_AddSub_1176_src w  ⊑ alive_AddSub_1176_tgt w  := by
   unfold alive_AddSub_1176_src alive_AddSub_1176_tgt
@@ -245,21 +245,21 @@ theorem alive_AddSub_1176  (w : Nat)   : alive_AddSub_1176_src w  ⊑ alive_AddS
 def alive_AddSub_1202_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%x,%v1) : (_, _) -> (_)
-  %v3 = "llvm.add" (%v2,%C) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %x, %v1
+  %v3 = llvm.add %v2, %C
+  llvm.return %v3
 }]
 
 def alive_AddSub_1202_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%x,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = 1 : _ } :() -> (_)
-  %v4 = "llvm.sub" (%C,%v3) : (_, _) -> (_)
-  %v5 = "llvm.sub" (%v4,%x) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %x, %v1
+  %v3 = llvm.mlir.constant 1
+  %v4 = llvm.sub %C, %v3
+  %v5 = llvm.sub %v4, %x
+  llvm.return %v5
 }]
 theorem alive_AddSub_1202  (w : Nat)   : alive_AddSub_1202_src w  ⊑ alive_AddSub_1202_tgt w  := by
   unfold alive_AddSub_1202_src alive_AddSub_1202_tgt
@@ -283,19 +283,19 @@ theorem alive_AddSub_1202  (w : Nat)   : alive_AddSub_1202_src w  ⊑ alive_AddS
 def alive_AddSub_1295_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%a,%b) : (_, _) -> (_)
-  %v3 = "llvm.add" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.xor %a, %b
+  %v3 = llvm.add %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AddSub_1295_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%a,%b) : (_, _) -> (_)
-  %v3 = "llvm.or" (%a,%b) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.xor %a, %b
+  %v3 = llvm.or %a, %b
+  llvm.return %v3
 }]
 theorem alive_AddSub_1295  (w : Nat)   : alive_AddSub_1295_src w  ⊑ alive_AddSub_1295_tgt w  := by
   unfold alive_AddSub_1295_src alive_AddSub_1295_tgt
@@ -319,19 +319,19 @@ theorem alive_AddSub_1295  (w : Nat)   : alive_AddSub_1295_src w  ⊑ alive_AddS
 def alive_AddSub_1309_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.or" (%a,%b) : (_, _) -> (_)
-  %v3 = "llvm.add" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.or %a, %b
+  %v3 = llvm.add %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AddSub_1309_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.or" (%a,%b) : (_, _) -> (_)
-  %v3 = "llvm.add" (%a,%b) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.or %a, %b
+  %v3 = llvm.add %a, %b
+  llvm.return %v3
 }]
 theorem alive_AddSub_1309  (w : Nat)   : alive_AddSub_1309_src w  ⊑ alive_AddSub_1309_tgt w  := by
   unfold alive_AddSub_1309_src alive_AddSub_1309_tgt
@@ -353,19 +353,19 @@ theorem alive_AddSub_1309  (w : Nat)   : alive_AddSub_1309_src w  ⊑ alive_AddS
 def alive_AddSub_1539_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %x : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%a) : (_, _) -> (_)
-  %v3 = "llvm.sub" (%x,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %a
+  %v3 = llvm.sub %x, %v2
+  llvm.return %v3
 }]
 
 def alive_AddSub_1539_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %x : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%a) : (_, _) -> (_)
-  %v3 = "llvm.add" (%x,%a) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %a
+  %v3 = llvm.add %x, %a
+  llvm.return %v3
 }]
 theorem alive_AddSub_1539  (w : Nat)   : alive_AddSub_1539_src w  ⊑ alive_AddSub_1539_tgt w  := by
   unfold alive_AddSub_1539_src alive_AddSub_1539_tgt
@@ -385,16 +385,16 @@ theorem alive_AddSub_1539  (w : Nat)   : alive_AddSub_1539_src w  ⊑ alive_AddS
 def alive_AddSub_1539_2_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.sub" (%x,%C) : (_, _) -> (_)
-  "llvm.return" (%v1) : (_) -> ()
+  %v1 = llvm.sub %x, %C
+  llvm.return %v1
 }]
 
 def alive_AddSub_1539_2_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.neg" (%C) : (_) -> (_)
-  %v2 = "llvm.add" (%x,%v1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.neg %C
+  %v2 = llvm.add %x, %v1
+  llvm.return %v2
 }]
 theorem alive_AddSub_1539_2  (w : Nat)   : alive_AddSub_1539_2_src w  ⊑ alive_AddSub_1539_2_tgt w  := by
   unfold alive_AddSub_1539_2_src alive_AddSub_1539_2_tgt
@@ -414,15 +414,15 @@ theorem alive_AddSub_1539_2  (w : Nat)   : alive_AddSub_1539_2_src w  ⊑ alive_
 def alive_AddSub_1556_src   :=
 [alive_icom ()| {
 ^bb0(%y : i1, %x : i1):
-  %v1 = "llvm.sub" (%x,%y) : (i1, i1) -> (i1)
-  "llvm.return" (%v1) : (i1) -> ()
+  %v1 = llvm.sub %x, %y : i1
+  llvm.return %v1 : i1
 }]
 
 def alive_AddSub_1556_tgt  :=
 [alive_icom ()| {
 ^bb0(%y : i1, %x : i1):
-  %v1 = "llvm.xor" (%x,%y) : (i1, i1) -> (i1)
-  "llvm.return" (%v1) : (i1) -> ()
+  %v1 = llvm.xor %x, %y : i1
+  llvm.return %v1 : i1
 }]
 theorem alive_AddSub_1556   : alive_AddSub_1556_src ⊑ alive_AddSub_1556_tgt := by
   unfold alive_AddSub_1556_src alive_AddSub_1556_tgt
@@ -442,17 +442,17 @@ theorem alive_AddSub_1556   : alive_AddSub_1556_src ⊑ alive_AddSub_1556_tgt :=
 def alive_AddSub_1560_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%a) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.sub %v1, %a
+  llvm.return %v2
 }]
 
 def alive_AddSub_1560_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%a,%v1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %a, %v1
+  llvm.return %v2
 }]
 theorem alive_AddSub_1560  (w : Nat)   : alive_AddSub_1560_src w  ⊑ alive_AddSub_1560_tgt w  := by
   unfold alive_AddSub_1560_src alive_AddSub_1560_tgt
@@ -474,21 +474,21 @@ theorem alive_AddSub_1560  (w : Nat)   : alive_AddSub_1560_src w  ⊑ alive_AddS
 def alive_AddSub_1564_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%x,%v1) : (_, _) -> (_)
-  %v3 = "llvm.sub" (%C,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %x, %v1
+  %v3 = llvm.sub %C, %v2
+  llvm.return %v3
 }]
 
 def alive_AddSub_1564_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%x,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = 1 : _ } :() -> (_)
-  %v4 = "llvm.add" (%C,%v3) : (_, _) -> (_)
-  %v5 = "llvm.add" (%x,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %x, %v1
+  %v3 = llvm.mlir.constant 1
+  %v4 = llvm.add %C, %v3
+  %v5 = llvm.add %x, %v4
+  llvm.return %v5
 }]
 theorem alive_AddSub_1564  (w : Nat)   : alive_AddSub_1564_src w  ⊑ alive_AddSub_1564_tgt w  := by
   unfold alive_AddSub_1564_src alive_AddSub_1564_tgt
@@ -510,18 +510,18 @@ theorem alive_AddSub_1564  (w : Nat)   : alive_AddSub_1564_src w  ⊑ alive_AddS
 def alive_AddSub_1574_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
-  %v1 = "llvm.add" (%X,%C2) : (_, _) -> (_)
-  %v2 = "llvm.sub" (%C,%v1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.add %X, %C2
+  %v2 = llvm.sub %C, %v1
+  llvm.return %v2
 }]
 
 def alive_AddSub_1574_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
-  %v1 = "llvm.add" (%X,%C2) : (_, _) -> (_)
-  %v2 = "llvm.sub" (%C,%C2) : (_, _) -> (_)
-  %v3 = "llvm.sub" (%v2,%X) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.add %X, %C2
+  %v2 = llvm.sub %C, %C2
+  %v3 = llvm.sub %v2, %X
+  llvm.return %v3
 }]
 theorem alive_AddSub_1574  (w : Nat)   : alive_AddSub_1574_src w  ⊑ alive_AddSub_1574_tgt w  := by
   unfold alive_AddSub_1574_src alive_AddSub_1574_tgt
@@ -543,18 +543,18 @@ theorem alive_AddSub_1574  (w : Nat)   : alive_AddSub_1574_src w  ⊑ alive_AddS
 def alive_AddSub_1614_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.add" (%X,%Y) : (_, _) -> (_)
-  %v2 = "llvm.sub" (%X,%v1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.add %X, %Y
+  %v2 = llvm.sub %X, %v1
+  llvm.return %v2
 }]
 
 def alive_AddSub_1614_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.add" (%X,%Y) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v3 = "llvm.sub" (%v2,%Y) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.add %X, %Y
+  %v2 = llvm.mlir.constant 0
+  %v3 = llvm.sub %v2, %Y
+  llvm.return %v3
 }]
 theorem alive_AddSub_1614  (w : Nat)   : alive_AddSub_1614_src w  ⊑ alive_AddSub_1614_tgt w  := by
   unfold alive_AddSub_1614_src alive_AddSub_1614_tgt
@@ -576,18 +576,18 @@ theorem alive_AddSub_1614  (w : Nat)   : alive_AddSub_1614_src w  ⊑ alive_AddS
 def alive_AddSub_1619_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.sub" (%X,%Y) : (_, _) -> (_)
-  %v2 = "llvm.sub" (%v1,%X) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.sub %X, %Y
+  %v2 = llvm.sub %v1, %X
+  llvm.return %v2
 }]
 
 def alive_AddSub_1619_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.sub" (%X,%Y) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v3 = "llvm.sub" (%v2,%Y) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.sub %X, %Y
+  %v2 = llvm.mlir.constant 0
+  %v3 = llvm.sub %v2, %Y
+  llvm.return %v3
 }]
 theorem alive_AddSub_1619  (w : Nat)   : alive_AddSub_1619_src w  ⊑ alive_AddSub_1619_tgt w  := by
   unfold alive_AddSub_1619_src alive_AddSub_1619_tgt
@@ -611,19 +611,19 @@ theorem alive_AddSub_1619  (w : Nat)   : alive_AddSub_1619_src w  ⊑ alive_AddS
 def alive_AddSub_1624_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v3 = "llvm.sub" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.or %A, %B
+  %v2 = llvm.xor %A, %B
+  %v3 = llvm.sub %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AddSub_1624_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v3 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.or %A, %B
+  %v2 = llvm.xor %A, %B
+  %v3 = llvm.and %A, %B
+  llvm.return %v3
 }]
 theorem alive_AddSub_1624  (w : Nat)   : alive_AddSub_1624_src w  ⊑ alive_AddSub_1624_tgt w  := by
   unfold alive_AddSub_1624_src alive_AddSub_1624_tgt
@@ -646,19 +646,19 @@ theorem alive_AddSub_1624  (w : Nat)   : alive_AddSub_1624_src w  ⊑ alive_AddS
 def alive_AndOrXor_135_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C1 : _, %C2 : _):
-  %v1 = "llvm.xor" (%X,%C1) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%C2) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.xor %X, %C1
+  %v2 = llvm.and %v1, %C2
+  llvm.return %v2
 }]
 
 def alive_AndOrXor_135_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C1 : _, %C2 : _):
-  %v1 = "llvm.and" (%X,%C2) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%X,%C1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%C1,%C2) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%v1,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.and %X, %C2
+  %v2 = llvm.xor %X, %C1
+  %v3 = llvm.and %C1, %C2
+  %v4 = llvm.xor %v1, %v3
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_135  (w : Nat)   : alive_AndOrXor_135_src w  ⊑ alive_AndOrXor_135_tgt w  := by
   unfold alive_AndOrXor_135_src alive_AndOrXor_135_tgt
@@ -681,19 +681,19 @@ theorem alive_AndOrXor_135  (w : Nat)   : alive_AndOrXor_135_src w  ⊑ alive_An
 def alive_AndOrXor_144_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C1 : _, %C2 : _):
-  %v1 = "llvm.or" (%X,%C1) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%C2) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.or %X, %C1
+  %v2 = llvm.and %v1, %C2
+  llvm.return %v2
 }]
 
 def alive_AndOrXor_144_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C1 : _, %C2 : _):
-  %v1 = "llvm.and" (%C1,%C2) : (_, _) -> (_)
-  %v2 = "llvm.or" (%X,%v1) : (_, _) -> (_)
-  %v3 = "llvm.or" (%X,%C1) : (_, _) -> (_)
-  %v4 = "llvm.and" (%v2,%C2) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.and %C1, %C2
+  %v2 = llvm.or %X, %v1
+  %v3 = llvm.or %X, %C1
+  %v4 = llvm.and %v2, %C2
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_144  (w : Nat)   : alive_AndOrXor_144_src w  ⊑ alive_AndOrXor_144_tgt w  := by
   unfold alive_AndOrXor_144_src alive_AndOrXor_144_tgt
@@ -725,30 +725,30 @@ theorem alive_AndOrXor_144  (w : Nat)   : alive_AndOrXor_144_src w  ⊑ alive_An
 def alive_AndOrXor_698_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.and" (%a,%d) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v4 = "llvm.icmp.eq" (%v1,%v3) : (_, _) -> (i1)
-  %v5 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v6 = "llvm.icmp.eq" (%v2,%v5) : (_, _) -> (i1)
-  %v7 = "llvm.and" (%v4,%v6) : (i1, i1) -> (i1)
-  "llvm.return" (%v7) : (i1) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.and %a, %d
+  %v3 = llvm.mlir.constant 0
+  %v4 = llvm.icmp.eq %v1, %v3
+  %v5 = llvm.mlir.constant 0
+  %v6 = llvm.icmp.eq %v2, %v5
+  %v7 = llvm.and %v4, %v6 : i1
+  llvm.return %v7 : i1
 }]
 
 def alive_AndOrXor_698_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
-  %v1 = "llvm.or" (%b,%d) : (_, _) -> (_)
-  %v2 = "llvm.and" (%a,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v4 = "llvm.and" (%a,%d) : (_, _) -> (_)
-  %v5 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v6 = "llvm.icmp.eq" (%v3,%v5) : (_, _) -> (i1)
-  %v7 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v8 = "llvm.icmp.eq" (%v4,%v7) : (_, _) -> (_)
-  %v9 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v10 = "llvm.icmp.eq" (%v2,%v9) : (_, _) -> (i1)
-  "llvm.return" (%v10) : (i1) -> ()
+  %v1 = llvm.or %b, %d
+  %v2 = llvm.and %a, %v1
+  %v3 = llvm.and %a, %b
+  %v4 = llvm.and %a, %d
+  %v5 = llvm.mlir.constant 0
+  %v6 = llvm.icmp.eq %v3, %v5
+  %v7 = llvm.mlir.constant 0
+  %v8 = llvm.icmp.eq %v4, %v7
+  %v9 = llvm.mlir.constant 0
+  %v10 = llvm.icmp.eq %v2, %v9
+  llvm.return %v10 : i1
 }]
 theorem alive_AndOrXor_698  (w : Nat)   : alive_AndOrXor_698_src w  ⊑ alive_AndOrXor_698_tgt w  := by
   unfold alive_AndOrXor_698_src alive_AndOrXor_698_tgt
@@ -778,25 +778,25 @@ theorem alive_AndOrXor_698  (w : Nat)   : alive_AndOrXor_698_src w  ⊑ alive_An
 def alive_AndOrXor_709_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.and" (%a,%d) : (_, _) -> (i1)
-  %v3 = "llvm.icmp.eq" (%v1,%b) : (_, _) -> (i1)
-  %v4 = "llvm.icmp.eq" (%v2,%d) : (_, _) -> (i1)
-  %v5 = "llvm.and" (%v3,%v4) : (i1, i1) -> (i1)
-  "llvm.return" (%v5) : (i1) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.and %a, %d
+  %v3 = llvm.icmp.eq %v1, %b
+  %v4 = llvm.icmp.eq %v2, %d
+  %v5 = llvm.and %v3, %v4 : i1
+  llvm.return %v5 : i1
 }]
 
 def alive_AndOrXor_709_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
-  %v1 = "llvm.or" (%b,%d) : (_, _) -> (i1)
-  %v2 = "llvm.and" (%a,%v1) : (_, _) -> (i1)
-  %v3 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v4 = "llvm.and" (%a,%d) : (_, _) -> (_)
-  %v5 = "llvm.icmp.eq" (%v3,%b) : (_, _) -> (i1)
-  %v6 = "llvm.icmp.eq" (%v4,%d) : (_, _) -> (i1)
-  %v7 = "llvm.icmp.eq" (%v2,%v1) : (_, _) -> (i1)
-  "llvm.return" (%v7) : (i1) -> ()
+  %v1 = llvm.or %b, %d
+  %v2 = llvm.and %a, %v1
+  %v3 = llvm.and %a, %b
+  %v4 = llvm.and %a, %d
+  %v5 = llvm.icmp.eq %v3, %b
+  %v6 = llvm.icmp.eq %v4, %d
+  %v7 = llvm.icmp.eq %v2, %v1
+  llvm.return %v7 : i1
 }]
 theorem alive_AndOrXor_709  (w : Nat)   : alive_AndOrXor_709_src w  ⊑ alive_AndOrXor_709_tgt w  := by
   unfold alive_AndOrXor_709_src alive_AndOrXor_709_tgt
@@ -826,25 +826,25 @@ theorem alive_AndOrXor_709  (w : Nat)   : alive_AndOrXor_709_src w  ⊑ alive_An
 def alive_AndOrXor_716_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.and" (%a,%d) : (_, _) -> (i1)
-  %v3 = "llvm.icmp.eq" (%v1,%a) : (_, _) -> (i1)
-  %v4 = "llvm.icmp.eq" (%v2,%a) : (_, _) -> (i1)
-  %v5 = "llvm.and" (%v3,%v4) : (i1, i1) -> (i1)
-  "llvm.return" (%v5) : (i1) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.and %a, %d
+  %v3 = llvm.icmp.eq %v1, %a
+  %v4 = llvm.icmp.eq %v2, %a
+  %v5 = llvm.and %v3, %v4 : i1
+  llvm.return %v5 : i1
 }]
 
 def alive_AndOrXor_716_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
-  %v1 = "llvm.and" (%b,%d) : (_, _) -> (i1)
-  %v2 = "llvm.and" (%a,%v1) : (_, _) -> (i1)
-  %v3 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v4 = "llvm.and" (%a,%d) : (_, _) -> (_)
-  %v5 = "llvm.icmp.eq" (%v3,%a) : (_, _) -> (i1)
-  %v6 = "llvm.icmp.eq" (%v4,%a) : (_, _) -> (i1)
-  %v7 = "llvm.icmp.eq" (%v2,%a) : (_, _) -> (i1)
-  "llvm.return" (%v7) : (i1) -> ()
+  %v1 = llvm.and %b, %d
+  %v2 = llvm.and %a, %v1
+  %v3 = llvm.and %a, %b
+  %v4 = llvm.and %a, %d
+  %v5 = llvm.icmp.eq %v3, %a
+  %v6 = llvm.icmp.eq %v4, %a
+  %v7 = llvm.icmp.eq %v2, %a
+  llvm.return %v7 : i1
 }]
 theorem alive_AndOrXor_716  (w : Nat)   : alive_AndOrXor_716_src w  ⊑ alive_AndOrXor_716_tgt w  := by
   unfold alive_AndOrXor_716_src alive_AndOrXor_716_tgt
@@ -868,19 +868,19 @@ theorem alive_AndOrXor_716  (w : Nat)   : alive_AndOrXor_716_src w  ⊑ alive_An
 def alive_AndOrXor_794_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.icmp.sgt" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.ne" (%a,%b) : (_, _) -> (i1)
-  %v3 = "llvm.and" (%v1,%v2) : (i1, i1) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.icmp.sgt %a, %b
+  %v2 = llvm.icmp.ne %a, %b
+  %v3 = llvm.and %v1, %v2 : i1
+  llvm.return %v3 : i1
 }]
 
 def alive_AndOrXor_794_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.icmp.sgt" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.ne" (%a,%b) : (_, _) -> (i1)
-  %v3 = "llvm.icmp.sgt" (%a,%b) : (_, _) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.icmp.sgt %a, %b
+  %v2 = llvm.icmp.ne %a, %b
+  %v3 = llvm.icmp.sgt %a, %b
+  llvm.return %v3 : i1
 }]
 theorem alive_AndOrXor_794  (w : Nat)   : alive_AndOrXor_794_src w  ⊑ alive_AndOrXor_794_tgt w  := by
   unfold alive_AndOrXor_794_src alive_AndOrXor_794_tgt
@@ -906,25 +906,25 @@ theorem alive_AndOrXor_794  (w : Nat)   : alive_AndOrXor_794_src w  ⊑ alive_An
 def alive_AndOrXor_827_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.icmp.eq" (%a,%v1) : (_, _) -> (i1)
-  %v3 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v4 = "llvm.icmp.eq" (%b,%v3) : (_, _) -> (i1)
-  %v5 = "llvm.and" (%v2,%v4) : (i1, i1) -> (i1)
-  "llvm.return" (%v5) : (i1) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.icmp.eq %a, %v1
+  %v3 = llvm.mlir.constant 0
+  %v4 = llvm.icmp.eq %b, %v3
+  %v5 = llvm.and %v2, %v4 : i1
+  llvm.return %v5 : i1
 }]
 
 def alive_AndOrXor_827_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.or" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v3 = "llvm.icmp.eq" (%a,%v2) : (_, _) -> (i1)
-  %v4 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v5 = "llvm.icmp.eq" (%b,%v4) : (_, _) -> (i1)
-  %v6 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v7 = "llvm.icmp.eq" (%v1,%v6) : (_, _) -> (i1)
-  "llvm.return" (%v7) : (i1) -> ()
+  %v1 = llvm.or %a, %b
+  %v2 = llvm.mlir.constant 0
+  %v3 = llvm.icmp.eq %a, %v2
+  %v4 = llvm.mlir.constant 0
+  %v5 = llvm.icmp.eq %b, %v4
+  %v6 = llvm.mlir.constant 0
+  %v7 = llvm.icmp.eq %v1, %v6
+  llvm.return %v7 : i1
 }]
 theorem alive_AndOrXor_827  (w : Nat)   : alive_AndOrXor_827_src w  ⊑ alive_AndOrXor_827_tgt w  := by
   unfold alive_AndOrXor_827_src alive_AndOrXor_827_tgt
@@ -948,20 +948,20 @@ theorem alive_AndOrXor_827  (w : Nat)   : alive_AndOrXor_827_src w  ⊑ alive_An
 def alive_AndOrXor_887_2_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %C1 : _):
-  %v1 = "llvm.icmp.eq" (%a,%C1) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.ne" (%a,%C1) : (_, _) -> (i1)
-  %v3 = "llvm.and" (%v1,%v2) : (i1, i1) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.icmp.eq %a, %C1
+  %v2 = llvm.icmp.ne %a, %C1
+  %v3 = llvm.and %v1, %v2 : i1
+  llvm.return %v3 : i1
 }]
 
 def alive_AndOrXor_887_2_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %C1 : _):
-  %v1 = "llvm.icmp.eq" (%a,%C1) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.ne" (%a,%C1) : (_, _) -> (i1)
-  %v3 = "llvm.mlir.constant" () { value = 0 : i1 } :() -> (i1)
-  %v4 = "llvm.copy" (%v3) : (i1) -> (i1)
-  "llvm.return" (%v4) : (i1) -> ()
+  %v1 = llvm.icmp.eq %a, %C1
+  %v2 = llvm.icmp.ne %a, %C1
+  %v3 = llvm.mlir.constant 0 :  i1
+  %v4 = llvm.copy %v3 : i1
+  llvm.return %v4 : i1
 }]
 theorem alive_AndOrXor_887_2  (w : Nat)   : alive_AndOrXor_887_2_src w  ⊑ alive_AndOrXor_887_2_tgt w  := by
   unfold alive_AndOrXor_887_2_src alive_AndOrXor_887_2_tgt
@@ -986,25 +986,25 @@ theorem alive_AndOrXor_887_2  (w : Nat)   : alive_AndOrXor_887_2_src w  ⊑ aliv
 def alive_AndOrXor_1230__A__B___A__B_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%notOp0 : _, %notOp1 : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%notOp0,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%notOp1,%v3) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v2,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %notOp0, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %notOp1, %v3
+  %v5 = llvm.and %v2, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_1230__A__B___A__B_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%notOp0 : _, %notOp1 : _):
-  %v1 = "llvm.or" (%notOp0,%notOp1) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%notOp0,%v2) : (_, _) -> (_)
-  %v4 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v5 = "llvm.xor" (%notOp1,%v4) : (_, _) -> (_)
-  %v6 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v7 = "llvm.xor" (%v1,%v6) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.or %notOp0, %notOp1
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %notOp0, %v2
+  %v4 = llvm.mlir.constant -1
+  %v5 = llvm.xor %notOp1, %v4
+  %v6 = llvm.mlir.constant -1
+  %v7 = llvm.xor %v1, %v6
+  llvm.return %v7
 }]
 theorem alive_AndOrXor_1230__A__B___A__B  (w : Nat)   : alive_AndOrXor_1230__A__B___A__B_src w  ⊑ alive_AndOrXor_1230__A__B___A__B_tgt w  := by
   unfold alive_AndOrXor_1230__A__B___A__B_src alive_AndOrXor_1230__A__B___A__B_tgt
@@ -1030,23 +1030,23 @@ theorem alive_AndOrXor_1230__A__B___A__B  (w : Nat)   : alive_AndOrXor_1230__A__
 def alive_AndOrXor_1241_AB__AB__AB_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%v2,%v3) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v1,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.or %A, %B
+  %v2 = llvm.and %A, %B
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %v2, %v3
+  %v5 = llvm.and %v1, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_1241_AB__AB__AB_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%v2,%v3) : (_, _) -> (_)
-  %v5 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.or %A, %B
+  %v2 = llvm.and %A, %B
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %v2, %v3
+  %v5 = llvm.xor %A, %B
+  llvm.return %v5
 }]
 theorem alive_AndOrXor_1241_AB__AB__AB  (w : Nat)   : alive_AndOrXor_1241_AB__AB__AB_src w  ⊑ alive_AndOrXor_1241_AB__AB__AB_tgt w  := by
   unfold alive_AndOrXor_1241_AB__AB__AB_src alive_AndOrXor_1241_AB__AB__AB_tgt
@@ -1072,23 +1072,23 @@ theorem alive_AndOrXor_1241_AB__AB__AB  (w : Nat)   : alive_AndOrXor_1241_AB__AB
 def alive_AndOrXor_1247_AB__AB__AB_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  %v4 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v3,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.and %A, %B
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %v1, %v2
+  %v4 = llvm.or %A, %B
+  %v5 = llvm.and %v3, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_1247_AB__AB__AB_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  %v4 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v5 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.and %A, %B
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %v1, %v2
+  %v4 = llvm.or %A, %B
+  %v5 = llvm.xor %A, %B
+  llvm.return %v5
 }]
 theorem alive_AndOrXor_1247_AB__AB__AB  (w : Nat)   : alive_AndOrXor_1247_AB__AB__AB_src w  ⊑ alive_AndOrXor_1247_AB__AB__AB_tgt w  := by
   unfold alive_AndOrXor_1247_AB__AB__AB_src alive_AndOrXor_1247_AB__AB__AB_tgt
@@ -1111,19 +1111,19 @@ theorem alive_AndOrXor_1247_AB__AB__AB  (w : Nat)   : alive_AndOrXor_1247_AB__AB
 def alive_AndOrXor_1253_A__AB___A__B_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%A) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.xor %A, %B
+  %v2 = llvm.and %v1, %A
+  llvm.return %v2
 }]
 
 def alive_AndOrXor_1253_A__AB___A__B_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%B,%v1) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v4 = "llvm.and" (%A,%v2) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %B, %v1
+  %v3 = llvm.xor %A, %B
+  %v4 = llvm.and %A, %v2
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_1253_A__AB___A__B  (w : Nat)   : alive_AndOrXor_1253_A__AB___A__B_src w  ⊑ alive_AndOrXor_1253_A__AB___A__B_tgt w  := by
   unfold alive_AndOrXor_1253_A__AB___A__B_src alive_AndOrXor_1253_A__AB___A__B_tgt
@@ -1147,21 +1147,21 @@ theorem alive_AndOrXor_1253_A__AB___A__B  (w : Nat)   : alive_AndOrXor_1253_A__A
 def alive_AndOrXor_1280_ABA___AB_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%A,%v1) : (_, _) -> (_)
-  %v3 = "llvm.or" (%v2,%B) : (_, _) -> (_)
-  %v4 = "llvm.and" (%v3,%A) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %A, %v1
+  %v3 = llvm.or %v2, %B
+  %v4 = llvm.and %v3, %A
+  llvm.return %v4
 }]
 
 def alive_AndOrXor_1280_ABA___AB_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%A,%v1) : (_, _) -> (_)
-  %v3 = "llvm.or" (%v2,%B) : (_, _) -> (_)
-  %v4 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %A, %v1
+  %v3 = llvm.or %v2, %B
+  %v4 = llvm.and %A, %B
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_1280_ABA___AB  (w : Nat)   : alive_AndOrXor_1280_ABA___AB_src w  ⊑ alive_AndOrXor_1280_ABA___AB_tgt w  := by
   unfold alive_AndOrXor_1280_ABA___AB_src alive_AndOrXor_1280_ABA___AB_tgt
@@ -1188,23 +1188,23 @@ theorem alive_AndOrXor_1280_ABA___AB  (w : Nat)   : alive_AndOrXor_1280_ABA___AB
 def alive_AndOrXor_1288_A__B__B__C__A___A__B__C_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
-  %v1 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%B,%C) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%v2,%A) : (_, _) -> (_)
-  %v4 = "llvm.and" (%v1,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.xor %A, %B
+  %v2 = llvm.xor %B, %C
+  %v3 = llvm.xor %v2, %A
+  %v4 = llvm.and %v1, %v3
+  llvm.return %v4
 }]
 
 def alive_AndOrXor_1288_A__B__B__C__A___A__B__C_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
-  %v1 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%C,%v2) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%B,%C) : (_, _) -> (_)
-  %v5 = "llvm.xor" (%v4,%A) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v1,%v3) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.xor %A, %B
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %C, %v2
+  %v4 = llvm.xor %B, %C
+  %v5 = llvm.xor %v4, %A
+  %v6 = llvm.and %v1, %v3
+  llvm.return %v6
 }]
 theorem alive_AndOrXor_1288_A__B__B__C__A___A__B__C  (w : Nat)   : alive_AndOrXor_1288_A__B__B__C__A___A__B__C_src w  ⊑ alive_AndOrXor_1288_A__B__B__C__A___A__B__C_tgt w  := by
   unfold alive_AndOrXor_1288_A__B__B__C__A___A__B__C_src alive_AndOrXor_1288_A__B__B__C__A___A__B__C_tgt
@@ -1230,23 +1230,23 @@ theorem alive_AndOrXor_1288_A__B__B__C__A___A__B__C  (w : Nat)   : alive_AndOrXo
 def alive_AndOrXor_1294_A__B__A__B___A__B_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%A,%v2) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%v3,%B) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v1,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.or %A, %B
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %A, %v2
+  %v4 = llvm.xor %v3, %B
+  %v5 = llvm.and %v1, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_1294_A__B__A__B___A__B_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%A,%v2) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%v3,%B) : (_, _) -> (_)
-  %v5 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.or %A, %B
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %A, %v2
+  %v4 = llvm.xor %v3, %B
+  %v5 = llvm.and %A, %B
+  llvm.return %v5
 }]
 theorem alive_AndOrXor_1294_A__B__A__B___A__B  (w : Nat)   : alive_AndOrXor_1294_A__B__A__B___A__B_src w  ⊑ alive_AndOrXor_1294_A__B__A__B___A__B_tgt w  := by
   unfold alive_AndOrXor_1294_A__B__A__B___A__B_src alive_AndOrXor_1294_A__B__A__B___A__B_tgt
@@ -1270,19 +1270,19 @@ theorem alive_AndOrXor_1294_A__B__A__B___A__B  (w : Nat)   : alive_AndOrXor_1294
 def alive_AndOrXor_1683_1_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.icmp.ugt" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.eq" (%a,%b) : (_, _) -> (i1)
-  %v3 = "llvm.or" (%v1,%v2) : (i1, i1) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.icmp.ugt %a, %b
+  %v2 = llvm.icmp.eq %a, %b
+  %v3 = llvm.or %v1, %v2 : i1
+  llvm.return %v3 : i1
 }]
 
 def alive_AndOrXor_1683_1_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.icmp.ugt" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.eq" (%a,%b) : (_, _) -> (i1)
-  %v3 = "llvm.icmp.uge" (%a,%b) : (_, _) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.icmp.ugt %a, %b
+  %v2 = llvm.icmp.eq %a, %b
+  %v3 = llvm.icmp.uge %a, %b
+  llvm.return %v3 : i1
 }]
 theorem alive_AndOrXor_1683_1  (w : Nat)   : alive_AndOrXor_1683_1_src w  ⊑ alive_AndOrXor_1683_1_tgt w  := by
   unfold alive_AndOrXor_1683_1_src alive_AndOrXor_1683_1_tgt
@@ -1306,20 +1306,20 @@ theorem alive_AndOrXor_1683_1  (w : Nat)   : alive_AndOrXor_1683_1_src w  ⊑ al
 def alive_AndOrXor_1683_2_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.icmp.uge" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.ne" (%a,%b) : (_, _) -> (i1)
-  %v3 = "llvm.or" (%v1,%v2) : (i1, i1) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.icmp.uge %a, %b
+  %v2 = llvm.icmp.ne %a, %b
+  %v3 = llvm.or %v1, %v2 : i1
+  llvm.return %v3 : i1
 }]
 
 def alive_AndOrXor_1683_2_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.icmp.uge" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.ne" (%a,%b) : (_, _) -> (i1)
-  %v3 = "llvm.mlir.constant" () { value = 1 : i1 } :() -> (i1)
-  %v4 = "llvm.copy" (%v3) : (i1) -> (i1)
-  "llvm.return" (%v4) : (i1) -> ()
+  %v1 = llvm.icmp.uge %a, %b
+  %v2 = llvm.icmp.ne %a, %b
+  %v3 = llvm.mlir.constant 1 :  i1
+  %v4 = llvm.copy %v3 : i1
+  llvm.return %v4 : i1
 }]
 theorem alive_AndOrXor_1683_2  (w : Nat)   : alive_AndOrXor_1683_2_src w  ⊑ alive_AndOrXor_1683_2_tgt w  := by
   unfold alive_AndOrXor_1683_2_src alive_AndOrXor_1683_2_tgt
@@ -1345,23 +1345,23 @@ theorem alive_AndOrXor_1683_2  (w : Nat)   : alive_AndOrXor_1683_2_src w  ⊑ al
 def alive_AndOrXor_1704_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.icmp.eq" (%B,%v1) : (_, _) -> (i1)
-  %v3 = "llvm.icmp.ult" (%A,%B) : (_, _) -> (i1)
-  %v4 = "llvm.or" (%v2,%v3) : (i1, i1) -> (i1)
-  "llvm.return" (%v4) : (i1) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.icmp.eq %B, %v1
+  %v3 = llvm.icmp.ult %A, %B
+  %v4 = llvm.or %v2, %v3 : i1
+  llvm.return %v4 : i1
 }]
 
 def alive_AndOrXor_1704_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.add" (%B,%v1) : (_, _) -> (i1)
-  %v3 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v4 = "llvm.icmp.eq" (%B,%v3) : (_, _) -> (i1)
-  %v5 = "llvm.icmp.ult" (%A,%B) : (_, _) -> (i1)
-  %v6 = "llvm.icmp.uge" (%v2,%A) : (_, _) -> (i1)
-  "llvm.return" (%v6) : (i1) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.add %B, %v1
+  %v3 = llvm.mlir.constant 0
+  %v4 = llvm.icmp.eq %B, %v3
+  %v5 = llvm.icmp.ult %A, %B
+  %v6 = llvm.icmp.uge %v2, %A
+  llvm.return %v6 : i1
 }]
 theorem alive_AndOrXor_1704  (w : Nat)   : alive_AndOrXor_1704_src w  ⊑ alive_AndOrXor_1704_tgt w  := by
   unfold alive_AndOrXor_1704_src alive_AndOrXor_1704_tgt
@@ -1387,23 +1387,23 @@ theorem alive_AndOrXor_1704  (w : Nat)   : alive_AndOrXor_1704_src w  ⊑ alive_
 def alive_AndOrXor_1705_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (i1)
-  %v2 = "llvm.icmp.eq" (%B,%v1) : (_, _) -> (i1)
-  %v3 = "llvm.icmp.ugt" (%B,%A) : (_, _) -> (i1)
-  %v4 = "llvm.or" (%v2,%v3) : (i1, i1) -> (i1)
-  "llvm.return" (%v4) : (i1) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.icmp.eq %B, %v1
+  %v3 = llvm.icmp.ugt %B, %A
+  %v4 = llvm.or %v2, %v3 : i1
+  llvm.return %v4 : i1
 }]
 
 def alive_AndOrXor_1705_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (i1)
-  %v2 = "llvm.add" (%B,%v1) : (_, _) -> (i1)
-  %v3 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v4 = "llvm.icmp.eq" (%B,%v3) : (_, _) -> (i1)
-  %v5 = "llvm.icmp.ugt" (%B,%A) : (_, _) -> (i1)
-  %v6 = "llvm.icmp.uge" (%v2,%A) : (_, _) -> (i1)
-  "llvm.return" (%v6) : (i1) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.add %B, %v1
+  %v3 = llvm.mlir.constant 0
+  %v4 = llvm.icmp.eq %B, %v3
+  %v5 = llvm.icmp.ugt %B, %A
+  %v6 = llvm.icmp.uge %v2, %A
+  llvm.return %v6 : i1
 }]
 theorem alive_AndOrXor_1705  (w : Nat)   : alive_AndOrXor_1705_src w  ⊑ alive_AndOrXor_1705_tgt w  := by
   unfold alive_AndOrXor_1705_src alive_AndOrXor_1705_tgt
@@ -1429,25 +1429,25 @@ theorem alive_AndOrXor_1705  (w : Nat)   : alive_AndOrXor_1705_src w  ⊑ alive_
 def alive_AndOrXor_1733_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (i1)
-  %v2 = "llvm.icmp.ne" (%A,%v1) : (_, _) -> (i1)
-  %v3 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (i1)
-  %v4 = "llvm.icmp.ne" (%B,%v3) : (_, _) -> (i1)
-  %v5 = "llvm.or" (%v2,%v4) : (i1, i1) -> (i1)
-  "llvm.return" (%v5) : (i1) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.icmp.ne %A, %v1
+  %v3 = llvm.mlir.constant 0
+  %v4 = llvm.icmp.ne %B, %v3
+  %v5 = llvm.or %v2, %v4 : i1
+  llvm.return %v5 : i1
 }]
 
 def alive_AndOrXor_1733_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.or" (%A,%B) : (_, _) -> (i1)
-  %v2 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v3 = "llvm.icmp.ne" (%A,%v2) : (_, _) -> (i1)
-  %v4 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v5 = "llvm.icmp.ne" (%B,%v4) : (_, _) -> (i1)
-  %v6 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (i1)
-  %v7 = "llvm.icmp.ne" (%v1,%v6) : (_, _) -> (i1)
-  "llvm.return" (%v7) : (i1) -> ()
+  %v1 = llvm.or %A, %B
+  %v2 = llvm.mlir.constant 0
+  %v3 = llvm.icmp.ne %A, %v2
+  %v4 = llvm.mlir.constant 0
+  %v5 = llvm.icmp.ne %B, %v4
+  %v6 = llvm.mlir.constant 0
+  %v7 = llvm.icmp.ne %v1, %v6
+  llvm.return %v7 : i1
 }]
 theorem alive_AndOrXor_1733  (w : Nat)   : alive_AndOrXor_1733_src w  ⊑ alive_AndOrXor_1733_tgt w  := by
   unfold alive_AndOrXor_1733_src alive_AndOrXor_1733_tgt
@@ -1470,20 +1470,20 @@ theorem alive_AndOrXor_1733  (w : Nat)   : alive_AndOrXor_1733_src w  ⊑ alive_
 def alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C1 : _, %C : _):
-  %v1 = "llvm.xor" (%x,%C1) : (_, _) -> (_)
-  %v2 = "llvm.or" (%v1,%C) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.xor %x, %C1
+  %v2 = llvm.or %v1, %C
+  llvm.return %v2
 }]
 
 def alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C1 : _, %C : _):
-  %v1 = "llvm.or" (%x,%C) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%x,%C1) : (_, _) -> (_)
-  %v3 = "llvm.not" (%C) : (_) -> (_)
-  %v4 = "llvm.and" (%C1,%v3) : (_, _) -> (_)
-  %v5 = "llvm.xor" (%v1,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.or %x, %C
+  %v2 = llvm.xor %x, %C1
+  %v3 = llvm.not %C
+  %v4 = llvm.and %C1, %v3
+  %v5 = llvm.xor %v1, %v4
+  llvm.return %v5
 }]
 theorem alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2  (w : Nat)   : alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2_src w  ⊑ alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2_tgt w  := by
   unfold alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2_src alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2_tgt
@@ -1507,21 +1507,21 @@ theorem alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2  (w : Nat)   : alive_And
 def alive_AndOrXor_2113___A__B__A___A__B_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%A,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%B) : (_, _) -> (_)
-  %v4 = "llvm.or" (%v3,%A) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %A, %v1
+  %v3 = llvm.and %v2, %B
+  %v4 = llvm.or %v3, %A
+  llvm.return %v4
 }]
 
 def alive_AndOrXor_2113___A__B__A___A__B_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%A,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%B) : (_, _) -> (_)
-  %v4 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %A, %v1
+  %v3 = llvm.and %v2, %B
+  %v4 = llvm.or %A, %B
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_2113___A__B__A___A__B  (w : Nat)   : alive_AndOrXor_2113___A__B__A___A__B_src w  ⊑ alive_AndOrXor_2113___A__B__A___A__B_tgt w  := by
   unfold alive_AndOrXor_2113___A__B__A___A__B_src alive_AndOrXor_2113___A__B__A___A__B_tgt
@@ -1545,21 +1545,21 @@ theorem alive_AndOrXor_2113___A__B__A___A__B  (w : Nat)   : alive_AndOrXor_2113_
 def alive_AndOrXor_2118___A__B__A___A__B_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%A,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v4 = "llvm.or" (%v3,%v2) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %A, %v1
+  %v3 = llvm.and %A, %B
+  %v4 = llvm.or %v3, %v2
+  llvm.return %v4
 }]
 
 def alive_AndOrXor_2118___A__B__A___A__B_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%A,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v4 = "llvm.or" (%v2,%B) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %A, %v1
+  %v3 = llvm.and %A, %B
+  %v4 = llvm.or %v2, %B
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_2118___A__B__A___A__B  (w : Nat)   : alive_AndOrXor_2118___A__B__A___A__B_src w  ⊑ alive_AndOrXor_2118___A__B__A___A__B_tgt w  := by
   unfold alive_AndOrXor_2118___A__B__A___A__B_src alive_AndOrXor_2118___A__B__A___A__B_tgt
@@ -1585,23 +1585,23 @@ theorem alive_AndOrXor_2118___A__B__A___A__B  (w : Nat)   : alive_AndOrXor_2118_
 def alive_AndOrXor_2123___A__B__A__B___A__B_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%B,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%A,%v2) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v5 = "llvm.or" (%v3,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %B, %v1
+  %v3 = llvm.and %A, %v2
+  %v4 = llvm.xor %A, %B
+  %v5 = llvm.or %v3, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_2123___A__B__A__B___A__B_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%B,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%A,%v2) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v5 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %B, %v1
+  %v3 = llvm.and %A, %v2
+  %v4 = llvm.xor %A, %B
+  %v5 = llvm.xor %A, %B
+  llvm.return %v5
 }]
 theorem alive_AndOrXor_2123___A__B__A__B___A__B  (w : Nat)   : alive_AndOrXor_2123___A__B__A__B___A__B_src w  ⊑ alive_AndOrXor_2123___A__B__A__B___A__B_tgt w  := by
   unfold alive_AndOrXor_2123___A__B__A__B___A__B_src alive_AndOrXor_2123___A__B__A__B___A__B_tgt
@@ -1629,27 +1629,27 @@ theorem alive_AndOrXor_2123___A__B__A__B___A__B  (w : Nat)   : alive_AndOrXor_21
 def alive_AndOrXor_2188_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %D : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%D,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%A,%v3) : (_, _) -> (_)
-  %v5 = "llvm.and" (%A,%v2) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v4,%D) : (_, _) -> (_)
-  %v7 = "llvm.or" (%v5,%v6) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %D, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %A, %v3
+  %v5 = llvm.and %A, %v2
+  %v6 = llvm.and %v4, %D
+  %v7 = llvm.or %v5, %v6
+  llvm.return %v7
 }]
 
 def alive_AndOrXor_2188_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %D : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%D,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%A,%v3) : (_, _) -> (_)
-  %v5 = "llvm.and" (%A,%v2) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v4,%D) : (_, _) -> (_)
-  %v7 = "llvm.xor" (%A,%D) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %D, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %A, %v3
+  %v5 = llvm.and %A, %v2
+  %v6 = llvm.and %v4, %D
+  %v7 = llvm.xor %A, %D
+  llvm.return %v7
 }]
 theorem alive_AndOrXor_2188  (w : Nat)   : alive_AndOrXor_2188_src w  ⊑ alive_AndOrXor_2188_tgt w  := by
   unfold alive_AndOrXor_2188_src alive_AndOrXor_2188_tgt
@@ -1675,21 +1675,21 @@ theorem alive_AndOrXor_2188  (w : Nat)   : alive_AndOrXor_2188_src w  ⊑ alive_
 def alive_AndOrXor_2231__A__B__B__C__A___A__B__C_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
-  %v1 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%B,%C) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%v2,%A) : (_, _) -> (_)
-  %v4 = "llvm.or" (%v1,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.xor %A, %B
+  %v2 = llvm.xor %B, %C
+  %v3 = llvm.xor %v2, %A
+  %v4 = llvm.or %v1, %v3
+  llvm.return %v4
 }]
 
 def alive_AndOrXor_2231__A__B__B__C__A___A__B__C_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
-  %v1 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%B,%C) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%v2,%A) : (_, _) -> (_)
-  %v4 = "llvm.or" (%v1,%C) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.xor %A, %B
+  %v2 = llvm.xor %B, %C
+  %v3 = llvm.xor %v2, %A
+  %v4 = llvm.or %v1, %C
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_2231__A__B__B__C__A___A__B__C  (w : Nat)   : alive_AndOrXor_2231__A__B__B__C__A___A__B__C_src w  ⊑ alive_AndOrXor_2231__A__B__B__C__A___A__B__C_tgt w  := by
   unfold alive_AndOrXor_2231__A__B__B__C__A___A__B__C_src alive_AndOrXor_2231__A__B__B__C__A___A__B__C_tgt
@@ -1714,20 +1714,20 @@ theorem alive_AndOrXor_2231__A__B__B__C__A___A__B__C  (w : Nat)   : alive_AndOrX
 def alive_AndOrXor_2243__B__C__A__B___B__A__C_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
-  %v1 = "llvm.or" (%B,%C) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%A) : (_, _) -> (_)
-  %v3 = "llvm.or" (%v2,%B) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.or %B, %C
+  %v2 = llvm.and %v1, %A
+  %v3 = llvm.or %v2, %B
+  llvm.return %v3
 }]
 
 def alive_AndOrXor_2243__B__C__A__B___B__A__C_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
-  %v1 = "llvm.and" (%A,%C) : (_, _) -> (_)
-  %v2 = "llvm.or" (%B,%C) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%A) : (_, _) -> (_)
-  %v4 = "llvm.or" (%B,%v1) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.and %A, %C
+  %v2 = llvm.or %B, %C
+  %v3 = llvm.and %v2, %A
+  %v4 = llvm.or %B, %v1
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_2243__B__C__A__B___B__A__C  (w : Nat)   : alive_AndOrXor_2243__B__C__A__B___B__A__C_src w  ⊑ alive_AndOrXor_2243__B__C__A__B___B__A__C_tgt w  := by
   unfold alive_AndOrXor_2243__B__C__A__B___B__A__C_src alive_AndOrXor_2243__B__C__A__B___B__A__C_tgt
@@ -1752,25 +1752,25 @@ theorem alive_AndOrXor_2243__B__C__A__B___B__A__C  (w : Nat)   : alive_AndOrXor_
 def alive_AndOrXor_2247__A__B__A__B_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%A,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%B,%v3) : (_, _) -> (_)
-  %v5 = "llvm.or" (%v2,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %A, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %B, %v3
+  %v5 = llvm.or %v2, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_2247__A__B__A__B_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%A,%v2) : (_, _) -> (_)
-  %v4 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v5 = "llvm.xor" (%B,%v4) : (_, _) -> (_)
-  %v6 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v7 = "llvm.xor" (%v1,%v6) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.and %A, %B
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %A, %v2
+  %v4 = llvm.mlir.constant -1
+  %v5 = llvm.xor %B, %v4
+  %v6 = llvm.mlir.constant -1
+  %v7 = llvm.xor %v1, %v6
+  llvm.return %v7
 }]
 theorem alive_AndOrXor_2247__A__B__A__B  (w : Nat)   : alive_AndOrXor_2247__A__B__A__B_src w  ⊑ alive_AndOrXor_2247__A__B__A__B_tgt w  := by
   unfold alive_AndOrXor_2247__A__B__A__B_src alive_AndOrXor_2247__A__B__A__B_tgt
@@ -1792,17 +1792,17 @@ theorem alive_AndOrXor_2247__A__B__A__B  (w : Nat)   : alive_AndOrXor_2247__A__B
 def alive_AndOrXor_2263_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%B : _, %op0 : _):
-  %v1 = "llvm.xor" (%op0,%B) : (_, _) -> (_)
-  %v2 = "llvm.or" (%op0,%v1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.xor %op0, %B
+  %v2 = llvm.or %op0, %v1
+  llvm.return %v2
 }]
 
 def alive_AndOrXor_2263_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%B : _, %op0 : _):
-  %v1 = "llvm.xor" (%op0,%B) : (_, _) -> (_)
-  %v2 = "llvm.or" (%op0,%B) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.xor %op0, %B
+  %v2 = llvm.or %op0, %B
+  llvm.return %v2
 }]
 theorem alive_AndOrXor_2263  (w : Nat)   : alive_AndOrXor_2263_src w  ⊑ alive_AndOrXor_2263_tgt w  := by
   unfold alive_AndOrXor_2263_src alive_AndOrXor_2263_tgt
@@ -1827,23 +1827,23 @@ theorem alive_AndOrXor_2263  (w : Nat)   : alive_AndOrXor_2263_src w  ⊑ alive_
 def alive_AndOrXor_2264_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%A,%v1) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%v2,%B) : (_, _) -> (_)
-  %v4 = "llvm.or" (%A,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %A, %v1
+  %v3 = llvm.xor %v2, %B
+  %v4 = llvm.or %A, %v3
+  llvm.return %v4
 }]
 
 def alive_AndOrXor_2264_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%B,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%A,%v3) : (_, _) -> (_)
-  %v5 = "llvm.xor" (%v4,%B) : (_, _) -> (_)
-  %v6 = "llvm.or" (%A,%v2) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %B, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %A, %v3
+  %v5 = llvm.xor %v4, %B
+  %v6 = llvm.or %A, %v2
+  llvm.return %v6
 }]
 theorem alive_AndOrXor_2264  (w : Nat)   : alive_AndOrXor_2264_src w  ⊑ alive_AndOrXor_2264_tgt w  := by
   unfold alive_AndOrXor_2264_src alive_AndOrXor_2264_tgt
@@ -1867,19 +1867,19 @@ theorem alive_AndOrXor_2264  (w : Nat)   : alive_AndOrXor_2264_src w  ⊑ alive_
 def alive_AndOrXor_2265_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v3 = "llvm.or" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %A, %B
+  %v2 = llvm.xor %A, %B
+  %v3 = llvm.or %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AndOrXor_2265_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v3 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %A, %B
+  %v2 = llvm.xor %A, %B
+  %v3 = llvm.or %A, %B
+  llvm.return %v3
 }]
 theorem alive_AndOrXor_2265  (w : Nat)   : alive_AndOrXor_2265_src w  ⊑ alive_AndOrXor_2265_tgt w  := by
   unfold alive_AndOrXor_2265_src alive_AndOrXor_2265_tgt
@@ -1904,23 +1904,23 @@ theorem alive_AndOrXor_2265  (w : Nat)   : alive_AndOrXor_2265_src w  ⊑ alive_
 def alive_AndOrXor_2284_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  %v4 = "llvm.or" (%A,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.or %A, %B
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %v1, %v2
+  %v4 = llvm.or %A, %v3
+  llvm.return %v4
 }]
 
 def alive_AndOrXor_2284_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%B,%v1) : (_, _) -> (_)
-  %v3 = "llvm.or" (%A,%B) : (_, _) -> (_)
-  %v4 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v5 = "llvm.xor" (%v3,%v4) : (_, _) -> (_)
-  %v6 = "llvm.or" (%A,%v2) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %B, %v1
+  %v3 = llvm.or %A, %B
+  %v4 = llvm.mlir.constant -1
+  %v5 = llvm.xor %v3, %v4
+  %v6 = llvm.or %A, %v2
+  llvm.return %v6
 }]
 theorem alive_AndOrXor_2284  (w : Nat)   : alive_AndOrXor_2284_src w  ⊑ alive_AndOrXor_2284_tgt w  := by
   unfold alive_AndOrXor_2284_src alive_AndOrXor_2284_tgt
@@ -1945,23 +1945,23 @@ theorem alive_AndOrXor_2284  (w : Nat)   : alive_AndOrXor_2284_src w  ⊑ alive_
 def alive_AndOrXor_2285_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  %v4 = "llvm.or" (%A,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.xor %A, %B
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %v1, %v2
+  %v4 = llvm.or %A, %v3
+  llvm.return %v4
 }]
 
 def alive_AndOrXor_2285_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%B,%v1) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%A,%B) : (_, _) -> (_)
-  %v4 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v5 = "llvm.xor" (%v3,%v4) : (_, _) -> (_)
-  %v6 = "llvm.or" (%A,%v2) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %B, %v1
+  %v3 = llvm.xor %A, %B
+  %v4 = llvm.mlir.constant -1
+  %v5 = llvm.xor %v3, %v4
+  %v6 = llvm.or %A, %v2
+  llvm.return %v6
 }]
 theorem alive_AndOrXor_2285  (w : Nat)   : alive_AndOrXor_2285_src w  ⊑ alive_AndOrXor_2285_tgt w  := by
   unfold alive_AndOrXor_2285_src alive_AndOrXor_2285_tgt
@@ -1987,23 +1987,23 @@ theorem alive_AndOrXor_2285  (w : Nat)   : alive_AndOrXor_2285_src w  ⊑ alive_
 def alive_AndOrXor_2297_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%A,%v2) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%v3,%B) : (_, _) -> (_)
-  %v5 = "llvm.or" (%v1,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.and %A, %B
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %A, %v2
+  %v4 = llvm.xor %v3, %B
+  %v5 = llvm.or %v1, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_2297_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %B : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%A,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%A,%B) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%v2,%B) : (_, _) -> (_)
-  %v5 = "llvm.xor" (%v2,%B) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %A, %v1
+  %v3 = llvm.and %A, %B
+  %v4 = llvm.xor %v2, %B
+  %v5 = llvm.xor %v2, %B
+  llvm.return %v5
 }]
 theorem alive_AndOrXor_2297  (w : Nat)   : alive_AndOrXor_2297_src w  ⊑ alive_AndOrXor_2297_tgt w  := by
   unfold alive_AndOrXor_2297_src alive_AndOrXor_2297_tgt
@@ -2026,18 +2026,18 @@ theorem alive_AndOrXor_2297  (w : Nat)   : alive_AndOrXor_2297_src w  ⊑ alive_
 def alive_AndOrXor_2367_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %C1 : _, %op1 : _):
-  %v1 = "llvm.or" (%A,%C1) : (_, _) -> (_)
-  %v2 = "llvm.or" (%v1,%op1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.or %A, %C1
+  %v2 = llvm.or %v1, %op1
+  llvm.return %v2
 }]
 
 def alive_AndOrXor_2367_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%A : _, %C1 : _, %op1 : _):
-  %v1 = "llvm.or" (%A,%op1) : (_, _) -> (_)
-  %v2 = "llvm.or" (%A,%C1) : (_, _) -> (_)
-  %v3 = "llvm.or" (%v1,%C1) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.or %A, %op1
+  %v2 = llvm.or %A, %C1
+  %v3 = llvm.or %v1, %C1
+  llvm.return %v3
 }]
 theorem alive_AndOrXor_2367  (w : Nat)   : alive_AndOrXor_2367_src w  ⊑ alive_AndOrXor_2367_tgt w  := by
   unfold alive_AndOrXor_2367_src alive_AndOrXor_2367_tgt
@@ -2062,24 +2062,24 @@ theorem alive_AndOrXor_2367  (w : Nat)   : alive_AndOrXor_2367_src w  ⊑ alive_
 def alive_AndOrXor_2416_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%nx : _, %y : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%nx,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%y) : (_, _) -> (_)
-  %v4 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v5 = "llvm.xor" (%v3,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %nx, %v1
+  %v3 = llvm.and %v2, %y
+  %v4 = llvm.mlir.constant -1
+  %v5 = llvm.xor %v3, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_2416_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%nx : _, %y : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%y,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%nx,%v3) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v4,%y) : (_, _) -> (_)
-  %v6 = "llvm.or" (%nx,%v2) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %y, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %nx, %v3
+  %v5 = llvm.and %v4, %y
+  %v6 = llvm.or %nx, %v2
+  llvm.return %v6
 }]
 theorem alive_AndOrXor_2416  (w : Nat)   : alive_AndOrXor_2416_src w  ⊑ alive_AndOrXor_2416_tgt w  := by
   unfold alive_AndOrXor_2416_src alive_AndOrXor_2416_tgt
@@ -2104,24 +2104,24 @@ theorem alive_AndOrXor_2416  (w : Nat)   : alive_AndOrXor_2416_src w  ⊑ alive_
 def alive_AndOrXor_2417_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%nx : _, %y : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%nx,%v1) : (_, _) -> (_)
-  %v3 = "llvm.or" (%v2,%y) : (_, _) -> (_)
-  %v4 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v5 = "llvm.xor" (%v3,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %nx, %v1
+  %v3 = llvm.or %v2, %y
+  %v4 = llvm.mlir.constant -1
+  %v5 = llvm.xor %v3, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_2417_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%nx : _, %y : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%y,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%nx,%v3) : (_, _) -> (_)
-  %v5 = "llvm.or" (%v4,%y) : (_, _) -> (_)
-  %v6 = "llvm.and" (%nx,%v2) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %y, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %nx, %v3
+  %v5 = llvm.or %v4, %y
+  %v6 = llvm.and %nx, %v2
+  llvm.return %v6
 }]
 theorem alive_AndOrXor_2417  (w : Nat)   : alive_AndOrXor_2417_src w  ⊑ alive_AndOrXor_2417_tgt w  := by
   unfold alive_AndOrXor_2417_src alive_AndOrXor_2417_tgt
@@ -2145,22 +2145,22 @@ theorem alive_AndOrXor_2417  (w : Nat)   : alive_AndOrXor_2417_src w  ⊑ alive_
 def alive_AndOrXor_2429_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%y : _, %x : _):
-  %v1 = "llvm.and" (%x,%y) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %x, %y
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AndOrXor_2429_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%y : _, %x : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%x,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%y,%v3) : (_, _) -> (_)
-  %v5 = "llvm.and" (%x,%y) : (_, _) -> (_)
-  %v6 = "llvm.or" (%v2,%v4) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %x, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %y, %v3
+  %v5 = llvm.and %x, %y
+  %v6 = llvm.or %v2, %v4
+  llvm.return %v6
 }]
 theorem alive_AndOrXor_2429  (w : Nat)   : alive_AndOrXor_2429_src w  ⊑ alive_AndOrXor_2429_tgt w  := by
   unfold alive_AndOrXor_2429_src alive_AndOrXor_2429_tgt
@@ -2184,22 +2184,22 @@ theorem alive_AndOrXor_2429  (w : Nat)   : alive_AndOrXor_2429_src w  ⊑ alive_
 def alive_AndOrXor_2430_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%y : _, %x : _):
-  %v1 = "llvm.or" (%x,%y) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.or %x, %y
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AndOrXor_2430_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%y : _, %x : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%x,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%y,%v3) : (_, _) -> (_)
-  %v5 = "llvm.or" (%x,%y) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v2,%v4) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %x, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %y, %v3
+  %v5 = llvm.or %x, %y
+  %v6 = llvm.and %v2, %v4
+  llvm.return %v6
 }]
 theorem alive_AndOrXor_2430  (w : Nat)   : alive_AndOrXor_2430_src w  ⊑ alive_AndOrXor_2430_tgt w  := by
   unfold alive_AndOrXor_2430_src alive_AndOrXor_2430_tgt
@@ -2223,22 +2223,22 @@ theorem alive_AndOrXor_2430  (w : Nat)   : alive_AndOrXor_2430_src w  ⊑ alive_
 def alive_AndOrXor_2443_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%y : _, %x : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%x,%v1) : (_, _) -> (_)
-  %v3 = "llvm.ashr" (%v2,%y) : (_, _) -> (_)
-  %v4 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v5 = "llvm.xor" (%v3,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %x, %v1
+  %v3 = llvm.ashr %v2, %y
+  %v4 = llvm.mlir.constant -1
+  %v5 = llvm.xor %v3, %v4
+  llvm.return %v5
 }]
 
 def alive_AndOrXor_2443_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%y : _, %x : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%x,%v1) : (_, _) -> (_)
-  %v3 = "llvm.ashr" (%v2,%y) : (_, _) -> (_)
-  %v4 = "llvm.ashr" (%x,%y) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %x, %v1
+  %v3 = llvm.ashr %v2, %y
+  %v4 = llvm.ashr %x, %y
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_2443  (w : Nat)   : alive_AndOrXor_2443_src w  ⊑ alive_AndOrXor_2443_tgt w  := by
   unfold alive_AndOrXor_2443_src alive_AndOrXor_2443_tgt
@@ -2261,18 +2261,18 @@ theorem alive_AndOrXor_2443  (w : Nat)   : alive_AndOrXor_2443_src w  ⊑ alive_
 def alive_AndOrXor_2453_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%y : _, %x : _):
-  %v1 = "llvm.icmp.slt" (%x,%y) : (_, _) -> (i1)
-  %v2 = "llvm.mlir.constant" () { value = -1 : i1 } :() -> (i1)
-  %v3 = "llvm.xor" (%v1,%v2) : (i1, i1) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.icmp.slt %x, %y
+  %v2 = llvm.mlir.constant -1 :  i1
+  %v3 = llvm.xor %v1, %v2 : i1
+  llvm.return %v3 : i1
 }]
 
 def alive_AndOrXor_2453_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%y : _, %x : _):
-  %v1 = "llvm.icmp.slt" (%x,%y) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.sge" (%x,%y) : (_, _) -> (i1)
-  "llvm.return" (%v2) : (i1) -> ()
+  %v1 = llvm.icmp.slt %x, %y
+  %v2 = llvm.icmp.sge %x, %y
+  llvm.return %v2 : i1
 }]
 theorem alive_AndOrXor_2453  (w : Nat)   : alive_AndOrXor_2453_src w  ⊑ alive_AndOrXor_2453_tgt w  := by
   unfold alive_AndOrXor_2453_src alive_AndOrXor_2453_tgt
@@ -2294,20 +2294,20 @@ theorem alive_AndOrXor_2453  (w : Nat)   : alive_AndOrXor_2453_src w  ⊑ alive_
 def alive_AndOrXor_2475_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.sub" (%C,%x) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.sub %C, %x
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AndOrXor_2475_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.sub" (%C,%x) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.sub" (%v2,%C) : (_, _) -> (_)
-  %v4 = "llvm.add" (%x,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.sub %C, %x
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.sub %v2, %C
+  %v4 = llvm.add %x, %v3
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_2475  (w : Nat)   : alive_AndOrXor_2475_src w  ⊑ alive_AndOrXor_2475_tgt w  := by
   unfold alive_AndOrXor_2475_src alive_AndOrXor_2475_tgt
@@ -2329,20 +2329,20 @@ theorem alive_AndOrXor_2475  (w : Nat)   : alive_AndOrXor_2475_src w  ⊑ alive_
 def alive_AndOrXor_2486_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.add" (%x,%C) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.add %x, %C
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AndOrXor_2486_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%x : _, %C : _):
-  %v1 = "llvm.add" (%x,%C) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.sub" (%v2,%C) : (_, _) -> (_)
-  %v4 = "llvm.sub" (%v3,%x) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.add %x, %C
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.sub %v2, %C
+  %v4 = llvm.sub %v3, %x
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_2486  (w : Nat)   : alive_AndOrXor_2486_src w  ⊑ alive_AndOrXor_2486_tgt w  := by
   unfold alive_AndOrXor_2486_src alive_AndOrXor_2486_tgt
@@ -2365,19 +2365,19 @@ theorem alive_AndOrXor_2486  (w : Nat)   : alive_AndOrXor_2486_src w  ⊑ alive_
 def alive_AndOrXor_2581__BAB___A__B_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %op1 : _):
-  %v1 = "llvm.or" (%a,%op1) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%v1,%op1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.or %a, %op1
+  %v2 = llvm.xor %v1, %op1
+  llvm.return %v2
 }]
 
 def alive_AndOrXor_2581__BAB___A__B_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %op1 : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%op1,%v1) : (_, _) -> (_)
-  %v3 = "llvm.or" (%a,%op1) : (_, _) -> (_)
-  %v4 = "llvm.and" (%a,%v2) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %op1, %v1
+  %v3 = llvm.or %a, %op1
+  %v4 = llvm.and %a, %v2
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_2581__BAB___A__B  (w : Nat)   : alive_AndOrXor_2581__BAB___A__B_src w  ⊑ alive_AndOrXor_2581__BAB___A__B_tgt w  := by
   unfold alive_AndOrXor_2581__BAB___A__B_src alive_AndOrXor_2581__BAB___A__B_tgt
@@ -2400,19 +2400,19 @@ theorem alive_AndOrXor_2581__BAB___A__B  (w : Nat)   : alive_AndOrXor_2581__BAB_
 def alive_AndOrXor_2587__BAA___B__A_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %op1 : _):
-  %v1 = "llvm.and" (%a,%op1) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%v1,%op1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.and %a, %op1
+  %v2 = llvm.xor %v1, %op1
+  llvm.return %v2
 }]
 
 def alive_AndOrXor_2587__BAA___B__A_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %op1 : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%a,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%a,%op1) : (_, _) -> (_)
-  %v4 = "llvm.and" (%v2,%op1) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %a, %v1
+  %v3 = llvm.and %a, %op1
+  %v4 = llvm.and %v2, %op1
+  llvm.return %v4
 }]
 theorem alive_AndOrXor_2587__BAA___B__A  (w : Nat)   : alive_AndOrXor_2587__BAA___B__A_src w  ⊑ alive_AndOrXor_2587__BAA___B__A_tgt w  := by
   unfold alive_AndOrXor_2587__BAA___B__A_src alive_AndOrXor_2587__BAA___B__A_tgt
@@ -2436,19 +2436,19 @@ theorem alive_AndOrXor_2587__BAA___B__A  (w : Nat)   : alive_AndOrXor_2587__BAA_
 def alive_AndOrXor_2595_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.or" (%a,%b) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.or %a, %b
+  %v3 = llvm.xor %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AndOrXor_2595_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.or" (%a,%b) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%a,%b) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.or %a, %b
+  %v3 = llvm.xor %a, %b
+  llvm.return %v3
 }]
 theorem alive_AndOrXor_2595  (w : Nat)   : alive_AndOrXor_2595_src w  ⊑ alive_AndOrXor_2595_tgt w  := by
   unfold alive_AndOrXor_2595_src alive_AndOrXor_2595_tgt
@@ -2476,27 +2476,27 @@ theorem alive_AndOrXor_2595  (w : Nat)   : alive_AndOrXor_2595_src w  ⊑ alive_
 def alive_AndOrXor_2607_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%a,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%b,%v3) : (_, _) -> (_)
-  %v5 = "llvm.or" (%a,%v4) : (_, _) -> (_)
-  %v6 = "llvm.or" (%v2,%b) : (_, _) -> (_)
-  %v7 = "llvm.xor" (%v5,%v6) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %a, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %b, %v3
+  %v5 = llvm.or %a, %v4
+  %v6 = llvm.or %v2, %b
+  %v7 = llvm.xor %v5, %v6
+  llvm.return %v7
 }]
 
 def alive_AndOrXor_2607_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%a,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%b,%v3) : (_, _) -> (_)
-  %v5 = "llvm.or" (%a,%v4) : (_, _) -> (_)
-  %v6 = "llvm.or" (%v2,%b) : (_, _) -> (_)
-  %v7 = "llvm.xor" (%a,%b) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %a, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %b, %v3
+  %v5 = llvm.or %a, %v4
+  %v6 = llvm.or %v2, %b
+  %v7 = llvm.xor %a, %b
+  llvm.return %v7
 }]
 theorem alive_AndOrXor_2607  (w : Nat)   : alive_AndOrXor_2607_src w  ⊑ alive_AndOrXor_2607_tgt w  := by
   unfold alive_AndOrXor_2607_src alive_AndOrXor_2607_tgt
@@ -2524,27 +2524,27 @@ theorem alive_AndOrXor_2607  (w : Nat)   : alive_AndOrXor_2607_src w  ⊑ alive_
 def alive_AndOrXor_2617_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%a,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%b,%v3) : (_, _) -> (_)
-  %v5 = "llvm.and" (%a,%v4) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v2,%b) : (_, _) -> (_)
-  %v7 = "llvm.xor" (%v5,%v6) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %a, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %b, %v3
+  %v5 = llvm.and %a, %v4
+  %v6 = llvm.and %v2, %b
+  %v7 = llvm.xor %v5, %v6
+  llvm.return %v7
 }]
 
 def alive_AndOrXor_2617_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%a,%v1) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v4 = "llvm.xor" (%b,%v3) : (_, _) -> (_)
-  %v5 = "llvm.and" (%a,%v4) : (_, _) -> (_)
-  %v6 = "llvm.and" (%v2,%b) : (_, _) -> (_)
-  %v7 = "llvm.xor" (%a,%b) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %a, %v1
+  %v3 = llvm.mlir.constant -1
+  %v4 = llvm.xor %b, %v3
+  %v5 = llvm.and %a, %v4
+  %v6 = llvm.and %v2, %b
+  %v7 = llvm.xor %a, %b
+  llvm.return %v7
 }]
 theorem alive_AndOrXor_2617  (w : Nat)   : alive_AndOrXor_2617_src w  ⊑ alive_AndOrXor_2617_tgt w  := by
   unfold alive_AndOrXor_2617_src alive_AndOrXor_2617_tgt
@@ -2570,22 +2570,22 @@ theorem alive_AndOrXor_2617  (w : Nat)   : alive_AndOrXor_2617_src w  ⊑ alive_
 def alive_AndOrXor_2627_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %c : _, %b : _):
-  %v1 = "llvm.xor" (%a,%c) : (_, _) -> (_)
-  %v2 = "llvm.or" (%a,%b) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.xor %a, %c
+  %v2 = llvm.or %a, %b
+  %v3 = llvm.xor %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AndOrXor_2627_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %c : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%a,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%b) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%a,%c) : (_, _) -> (_)
-  %v5 = "llvm.or" (%a,%b) : (_, _) -> (_)
-  %v6 = "llvm.xor" (%v3,%c) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %a, %v1
+  %v3 = llvm.and %v2, %b
+  %v4 = llvm.xor %a, %c
+  %v5 = llvm.or %a, %b
+  %v6 = llvm.xor %v3, %c
+  llvm.return %v6
 }]
 theorem alive_AndOrXor_2627  (w : Nat)   : alive_AndOrXor_2627_src w  ⊑ alive_AndOrXor_2627_tgt w  := by
   unfold alive_AndOrXor_2627_src alive_AndOrXor_2627_tgt
@@ -2609,19 +2609,19 @@ theorem alive_AndOrXor_2627  (w : Nat)   : alive_AndOrXor_2627_src w  ⊑ alive_
 def alive_AndOrXor_2647_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%a,%b) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%v1,%v2) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.xor %a, %b
+  %v3 = llvm.xor %v1, %v2
+  llvm.return %v3
 }]
 
 def alive_AndOrXor_2647_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%a,%b) : (_, _) -> (_)
-  %v3 = "llvm.or" (%a,%b) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.xor %a, %b
+  %v3 = llvm.or %a, %b
+  llvm.return %v3
 }]
 theorem alive_AndOrXor_2647  (w : Nat)   : alive_AndOrXor_2647_src w  ⊑ alive_AndOrXor_2647_tgt w  := by
   unfold alive_AndOrXor_2647_src alive_AndOrXor_2647_tgt
@@ -2648,27 +2648,27 @@ theorem alive_AndOrXor_2647  (w : Nat)   : alive_AndOrXor_2647_src w  ⊑ alive_
 def alive_AndOrXor_2658_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%b,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%a,%v2) : (_, _) -> (_)
-  %v4 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v5 = "llvm.xor" (%a,%v4) : (_, _) -> (_)
-  %v6 = "llvm.xor" (%v3,%v5) : (_, _) -> (_)
-  "llvm.return" (%v6) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %b, %v1
+  %v3 = llvm.and %a, %v2
+  %v4 = llvm.mlir.constant -1
+  %v5 = llvm.xor %a, %v4
+  %v6 = llvm.xor %v3, %v5
+  llvm.return %v6
 }]
 
 def alive_AndOrXor_2658_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.and" (%a,%b) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.xor" (%b,%v2) : (_, _) -> (_)
-  %v4 = "llvm.and" (%a,%v3) : (_, _) -> (_)
-  %v5 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v6 = "llvm.xor" (%a,%v5) : (_, _) -> (_)
-  %v7 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v8 = "llvm.xor" (%v1,%v7) : (_, _) -> (_)
-  "llvm.return" (%v8) : (_) -> ()
+  %v1 = llvm.and %a, %b
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.xor %b, %v2
+  %v4 = llvm.and %a, %v3
+  %v5 = llvm.mlir.constant -1
+  %v6 = llvm.xor %a, %v5
+  %v7 = llvm.mlir.constant -1
+  %v8 = llvm.xor %v1, %v7
+  llvm.return %v8
 }]
 theorem alive_AndOrXor_2658  (w : Nat)   : alive_AndOrXor_2658_src w  ⊑ alive_AndOrXor_2658_tgt w  := by
   unfold alive_AndOrXor_2658_src alive_AndOrXor_2658_tgt
@@ -2692,19 +2692,19 @@ theorem alive_AndOrXor_2658  (w : Nat)   : alive_AndOrXor_2658_src w  ⊑ alive_
 def alive_AndOrXor_2663_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.icmp.ule" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.ne" (%a,%b) : (_, _) -> (i1)
-  %v3 = "llvm.xor" (%v1,%v2) : (i1, i1) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.icmp.ule %a, %b
+  %v2 = llvm.icmp.ne %a, %b
+  %v3 = llvm.xor %v1, %v2 : i1
+  llvm.return %v3 : i1
 }]
 
 def alive_AndOrXor_2663_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.icmp.ule" (%a,%b) : (_, _) -> (i1)
-  %v2 = "llvm.icmp.ne" (%a,%b) : (_, _) -> (i1)
-  %v3 = "llvm.icmp.uge" (%a,%b) : (_, _) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.icmp.ule %a, %b
+  %v2 = llvm.icmp.ne %a, %b
+  %v3 = llvm.icmp.uge %a, %b
+  llvm.return %v3 : i1
 }]
 theorem alive_AndOrXor_2663  (w : Nat)   : alive_AndOrXor_2663_src w  ⊑ alive_AndOrXor_2663_tgt w  := by
   unfold alive_AndOrXor_2663_src alive_AndOrXor_2663_tgt
@@ -2724,17 +2724,17 @@ theorem alive_AndOrXor_2663  (w : Nat)   : alive_AndOrXor_2663_src w  ⊑ alive_
 def alive_152_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%x : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.mul" (%x,%v1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.mul %x, %v1
+  llvm.return %v2
 }]
 
 def alive_152_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%x : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%x) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %x
+  llvm.return %v2
 }]
 theorem alive_152  (w : Nat)   : alive_152_src w  ⊑ alive_152_tgt w  := by
   unfold alive_152_src alive_152_tgt
@@ -2758,19 +2758,19 @@ theorem alive_152  (w : Nat)   : alive_152_src w  ⊑ alive_152_tgt w  := by
 def alive_229_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C1 : _, %Op1 : _):
-  %v1 = "llvm.add" (%X,%C1) : (_, _) -> (_)
-  %v2 = "llvm.mul" (%v1,%Op1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.add %X, %C1
+  %v2 = llvm.mul %v1, %Op1
+  llvm.return %v2
 }]
 
 def alive_229_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C1 : _, %Op1 : _):
-  %v1 = "llvm.mul" (%C1,%Op1) : (_, _) -> (_)
-  %v2 = "llvm.mul" (%X,%Op1) : (_, _) -> (_)
-  %v3 = "llvm.add" (%X,%C1) : (_, _) -> (_)
-  %v4 = "llvm.add" (%v2,%v1) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.mul %C1, %Op1
+  %v2 = llvm.mul %X, %Op1
+  %v3 = llvm.add %X, %C1
+  %v4 = llvm.add %v2, %v1
+  llvm.return %v4
 }]
 theorem alive_229  (w : Nat)   : alive_229_src w  ⊑ alive_229_tgt w  := by
   unfold alive_229_src alive_229_tgt
@@ -2794,23 +2794,23 @@ theorem alive_229  (w : Nat)   : alive_229_src w  ⊑ alive_229_tgt w  := by
 def alive_239_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%X) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v4 = "llvm.sub" (%v3,%Y) : (_, _) -> (_)
-  %v5 = "llvm.mul" (%v2,%v4) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %X
+  %v3 = llvm.mlir.constant 0
+  %v4 = llvm.sub %v3, %Y
+  %v5 = llvm.mul %v2, %v4
+  llvm.return %v5
 }]
 
 def alive_239_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%X) : (_, _) -> (_)
-  %v3 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v4 = "llvm.sub" (%v3,%Y) : (_, _) -> (_)
-  %v5 = "llvm.mul" (%X,%Y) : (_, _) -> (_)
-  "llvm.return" (%v5) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %X
+  %v3 = llvm.mlir.constant 0
+  %v4 = llvm.sub %v3, %Y
+  %v5 = llvm.mul %X, %Y
+  llvm.return %v5
 }]
 theorem alive_239  (w : Nat)   : alive_239_src w  ⊑ alive_239_tgt w  := by
   unfold alive_239_src alive_239_tgt
@@ -2833,18 +2833,18 @@ theorem alive_239  (w : Nat)   : alive_239_src w  ⊑ alive_239_tgt w  := by
 def alive_275_src   :=
 [alive_icom ()| {
 ^bb0(%Y : i5, %X : i5):
-  %v1 = "llvm.udiv" (%X,%Y) : (i5, i5) -> (i5)
-  %v2 = "llvm.mul" (%v1,%Y) : (i5, i5) -> (i5)
-  "llvm.return" (%v2) : (i5) -> ()
+  %v1 = llvm.udiv %X, %Y : i5
+  %v2 = llvm.mul %v1, %Y : i5
+  llvm.return %v2 : i5
 }]
 
 def alive_275_tgt  :=
 [alive_icom ()| {
 ^bb0(%Y : i5, %X : i5):
-  %v1 = "llvm.urem" (%X,%Y) : (i5, i5) -> (i5)
-  %v2 = "llvm.udiv" (%X,%Y) : (i5, i5) -> (i5)
-  %v3 = "llvm.sub" (%X,%v1) : (i5, i5) -> (i5)
-  "llvm.return" (%v3) : (i5) -> ()
+  %v1 = llvm.urem %X, %Y : i5
+  %v2 = llvm.udiv %X, %Y : i5
+  %v3 = llvm.sub %X, %v1 : i5
+  llvm.return %v3 : i5
 }]
 theorem alive_275   : alive_275_src ⊑ alive_275_tgt := by
   unfold alive_275_src alive_275_tgt
@@ -2867,18 +2867,18 @@ theorem alive_275   : alive_275_src ⊑ alive_275_tgt := by
 def alive_275_2_src   :=
 [alive_icom ()| {
 ^bb0(%Y : i5, %X : i5):
-  %v1 = "llvm.sdiv" (%X,%Y) : (i5, i5) -> (i5)
-  %v2 = "llvm.mul" (%v1,%Y) : (i5, i5) -> (i5)
-  "llvm.return" (%v2) : (i5) -> ()
+  %v1 = llvm.sdiv %X, %Y : i5
+  %v2 = llvm.mul %v1, %Y : i5
+  llvm.return %v2 : i5
 }]
 
 def alive_275_2_tgt  :=
 [alive_icom ()| {
 ^bb0(%Y : i5, %X : i5):
-  %v1 = "llvm.srem" (%X,%Y) : (i5, i5) -> (i5)
-  %v2 = "llvm.sdiv" (%X,%Y) : (i5, i5) -> (i5)
-  %v3 = "llvm.sub" (%X,%v1) : (i5, i5) -> (i5)
-  "llvm.return" (%v3) : (i5) -> ()
+  %v1 = llvm.srem %X, %Y : i5
+  %v2 = llvm.sdiv %X, %Y : i5
+  %v3 = llvm.sub %X, %v1 : i5
+  llvm.return %v3 : i5
 }]
 theorem alive_275_2   : alive_275_2_src ⊑ alive_275_2_tgt := by
   unfold alive_275_2_src alive_275_2_tgt
@@ -2904,22 +2904,22 @@ theorem alive_275_2   : alive_275_2_src ⊑ alive_275_2_tgt := by
 def alive_276_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : i5, %X : i5):
-  %v1 = "llvm.sdiv" (%X,%Y) : (i5, i5) -> (i5)
-  %v2 = "llvm.mlir.constant" () { value = 0 : i5 } :() -> (i5)
-  %v3 = "llvm.sub" (%v2,%Y) : (i5, i5) -> (i5)
-  %v4 = "llvm.mul" (%v1,%v3) : (i5, i5) -> (i5)
-  "llvm.return" (%v4) : (i5) -> ()
+  %v1 = llvm.sdiv %X, %Y : i5
+  %v2 = llvm.mlir.constant 0 :  i5
+  %v3 = llvm.sub %v2, %Y : i5
+  %v4 = llvm.mul %v1, %v3 : i5
+  llvm.return %v4 : i5
 }]
 
 def alive_276_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : i5, %X : i5):
-  %v1 = "llvm.srem" (%X,%Y) : (i5, i5) -> (i5)
-  %v2 = "llvm.sdiv" (%X,%Y) : (i5, i5) -> (i5)
-  %v3 = "llvm.mlir.constant" () { value = 0 : i5 } :() -> (i5)
-  %v4 = "llvm.sub" (%v3,%Y) : (i5, i5) -> (i5)
-  %v5 = "llvm.sub" (%v1,%X) : (i5, i5) -> (i5)
-  "llvm.return" (%v5) : (i5) -> ()
+  %v1 = llvm.srem %X, %Y : i5
+  %v2 = llvm.sdiv %X, %Y : i5
+  %v3 = llvm.mlir.constant 0 :  i5
+  %v4 = llvm.sub %v3, %Y : i5
+  %v5 = llvm.sub %v1, %X : i5
+  llvm.return %v5 : i5
 }]
 theorem alive_276  (w : Nat)   : alive_276_src w  ⊑ alive_276_tgt w  := by
   unfold alive_276_src alive_276_tgt
@@ -2945,22 +2945,22 @@ theorem alive_276  (w : Nat)   : alive_276_src w  ⊑ alive_276_tgt w  := by
 def alive_276_2_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : i5, %X : i5):
-  %v1 = "llvm.udiv" (%X,%Y) : (i5, i5) -> (i5)
-  %v2 = "llvm.mlir.constant" () { value = 0 : i5 } :() -> (i5)
-  %v3 = "llvm.sub" (%v2,%Y) : (i5, i5) -> (i5)
-  %v4 = "llvm.mul" (%v1,%v3) : (i5, i5) -> (i5)
-  "llvm.return" (%v4) : (i5) -> ()
+  %v1 = llvm.udiv %X, %Y : i5
+  %v2 = llvm.mlir.constant 0 :  i5
+  %v3 = llvm.sub %v2, %Y : i5
+  %v4 = llvm.mul %v1, %v3 : i5
+  llvm.return %v4 : i5
 }]
 
 def alive_276_2_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : i5, %X : i5):
-  %v1 = "llvm.urem" (%X,%Y) : (i5, i5) -> (i5)
-  %v2 = "llvm.udiv" (%X,%Y) : (i5, i5) -> (i5)
-  %v3 = "llvm.mlir.constant" () { value = 0 : i5 } :() -> (i5)
-  %v4 = "llvm.sub" (%v3,%Y) : (i5, i5) -> (i5)
-  %v5 = "llvm.sub" (%v1,%X) : (i5, i5) -> (i5)
-  "llvm.return" (%v5) : (i5) -> ()
+  %v1 = llvm.urem %X, %Y : i5
+  %v2 = llvm.udiv %X, %Y : i5
+  %v3 = llvm.mlir.constant 0 :  i5
+  %v4 = llvm.sub %v3, %Y : i5
+  %v5 = llvm.sub %v1, %X : i5
+  llvm.return %v5 : i5
 }]
 theorem alive_276_2  (w : Nat)   : alive_276_2_src w  ⊑ alive_276_2_tgt w  := by
   unfold alive_276_2_src alive_276_2_tgt
@@ -2980,15 +2980,15 @@ theorem alive_276_2  (w : Nat)   : alive_276_2_src w  ⊑ alive_276_2_tgt w  := 
 def alive_283_src   :=
 [alive_icom ()| {
 ^bb0(%Y : i1, %X : i1):
-  %v1 = "llvm.mul" (%X,%Y) : (i1, i1) -> (i1)
-  "llvm.return" (%v1) : (i1) -> ()
+  %v1 = llvm.mul %X, %Y : i1
+  llvm.return %v1 : i1
 }]
 
 def alive_283_tgt  :=
 [alive_icom ()| {
 ^bb0(%Y : i1, %X : i1):
-  %v1 = "llvm.and" (%X,%Y) : (i1, i1) -> (i1)
-  "llvm.return" (%v1) : (i1) -> ()
+  %v1 = llvm.and %X, %Y : i1
+  llvm.return %v1 : i1
 }]
 theorem alive_283   : alive_283_src ⊑ alive_283_tgt := by
   unfold alive_283_src alive_283_tgt
@@ -3010,19 +3010,19 @@ theorem alive_283   : alive_283_src ⊑ alive_283_tgt := by
 def alive_290__292_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %Op1 : _):
-  %v1 = "llvm.mlir.constant" () { value = 1 : _ } :() -> (_)
-  %v2 = "llvm.shl" (%v1,%Y) : (_, _) -> (_)
-  %v3 = "llvm.mul" (%v2,%Op1) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant 1
+  %v2 = llvm.shl %v1, %Y
+  %v3 = llvm.mul %v2, %Op1
+  llvm.return %v3
 }]
 
 def alive_290__292_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %Op1 : _):
-  %v1 = "llvm.mlir.constant" () { value = 1 : _ } :() -> (_)
-  %v2 = "llvm.shl" (%v1,%Y) : (_, _) -> (_)
-  %v3 = "llvm.shl" (%Op1,%Y) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant 1
+  %v2 = llvm.shl %v1, %Y
+  %v3 = llvm.shl %Op1, %Y
+  llvm.return %v3
 }]
 theorem alive_290__292  (w : Nat)   : alive_290__292_src w  ⊑ alive_290__292_tgt w  := by
   unfold alive_290__292_src alive_290__292_tgt
@@ -3046,19 +3046,19 @@ theorem alive_290__292  (w : Nat)   : alive_290__292_src w  ⊑ alive_290__292_t
 def alive_820_src   :=
 [alive_icom ()| {
 ^bb0(%X : i9, %Op1 : i9):
-  %v1 = "llvm.srem" (%X,%Op1) : (i9, i9) -> (i9)
-  %v2 = "llvm.sub" (%X,%v1) : (i9, i9) -> (i9)
-  %v3 = "llvm.sdiv" (%v2,%Op1) : (i9, i9) -> (i9)
-  "llvm.return" (%v3) : (i9) -> ()
+  %v1 = llvm.srem %X, %Op1 : i9
+  %v2 = llvm.sub %X, %v1 : i9
+  %v3 = llvm.sdiv %v2, %Op1 : i9
+  llvm.return %v3 : i9
 }]
 
 def alive_820_tgt  :=
 [alive_icom ()| {
 ^bb0(%X : i9, %Op1 : i9):
-  %v1 = "llvm.srem" (%X,%Op1) : (i9, i9) -> (i9)
-  %v2 = "llvm.sub" (%X,%v1) : (i9, i9) -> (i9)
-  %v3 = "llvm.sdiv" (%X,%Op1) : (i9, i9) -> (i9)
-  "llvm.return" (%v3) : (i9) -> ()
+  %v1 = llvm.srem %X, %Op1 : i9
+  %v2 = llvm.sub %X, %v1 : i9
+  %v3 = llvm.sdiv %X, %Op1 : i9
+  llvm.return %v3 : i9
 }]
 theorem alive_820   : alive_820_src ⊑ alive_820_tgt := by
   unfold alive_820_src alive_820_tgt
@@ -3082,19 +3082,19 @@ theorem alive_820   : alive_820_src ⊑ alive_820_tgt := by
 def alive_820'_src   :=
 [alive_icom ()| {
 ^bb0(%X : i9, %Op1 : i9):
-  %v1 = "llvm.urem" (%X,%Op1) : (i9, i9) -> (i9)
-  %v2 = "llvm.sub" (%X,%v1) : (i9, i9) -> (i9)
-  %v3 = "llvm.udiv" (%v2,%Op1) : (i9, i9) -> (i9)
-  "llvm.return" (%v3) : (i9) -> ()
+  %v1 = llvm.urem %X, %Op1 : i9
+  %v2 = llvm.sub %X, %v1 : i9
+  %v3 = llvm.udiv %v2, %Op1 : i9
+  llvm.return %v3 : i9
 }]
 
 def alive_820'_tgt  :=
 [alive_icom ()| {
 ^bb0(%X : i9, %Op1 : i9):
-  %v1 = "llvm.urem" (%X,%Op1) : (i9, i9) -> (i9)
-  %v2 = "llvm.sub" (%X,%v1) : (i9, i9) -> (i9)
-  %v3 = "llvm.udiv" (%X,%Op1) : (i9, i9) -> (i9)
-  "llvm.return" (%v3) : (i9) -> ()
+  %v1 = llvm.urem %X, %Op1 : i9
+  %v2 = llvm.sub %X, %v1 : i9
+  %v3 = llvm.udiv %X, %Op1 : i9
+  llvm.return %v3 : i9
 }]
 theorem alive_820'   : alive_820'_src ⊑ alive_820'_tgt := by
   unfold alive_820'_src alive_820'_tgt
@@ -3114,17 +3114,17 @@ theorem alive_820'   : alive_820'_src ⊑ alive_820'_tgt := by
 def alive_1030_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.sdiv" (%X,%v1) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.sdiv %X, %v1
+  llvm.return %v2
 }]
 
 def alive_1030_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : _ } :() -> (_)
-  %v2 = "llvm.sub" (%v1,%X) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.mlir.constant 0
+  %v2 = llvm.sub %v1, %X
+  llvm.return %v2
 }]
 theorem alive_1030  (w : Nat)   : alive_1030_src w  ⊑ alive_1030_tgt w  := by
   unfold alive_1030_src alive_1030_tgt
@@ -3147,19 +3147,19 @@ theorem alive_1030  (w : Nat)   : alive_1030_src w  ⊑ alive_1030_tgt w  := by
 def alive_Select_858_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : i1, %b : i1):
-  %v1 = "llvm.mlir.constant" () { value = -1 : i1 } :() -> (i1)
-  %v2 = "llvm.xor" (%a,%v1) : (i1, i1) -> (i1)
-  %v3 = "llvm.select" (%a,%v2,%b) : (i1, i1, i1) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.mlir.constant -1 :  i1
+  %v2 = llvm.xor %a, %v1 : i1
+  %v3 = llvm.select %a,%v2, %b : i1, i1
+  llvm.return %v3 : i1
 }]
 
 def alive_Select_858_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%a,%v1) : (_, _) -> (_)
-  %v3 = "llvm.and" (%v2,%b) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %a, %v1
+  %v3 = llvm.and %v2, %b
+  llvm.return %v3
 }]
 theorem alive_Select_858  (w : Nat)   : alive_Select_858_src w  ⊑ alive_Select_858_tgt 1  := by
   unfold alive_Select_858_src alive_Select_858_tgt
@@ -3181,19 +3181,19 @@ theorem alive_Select_858  (w : Nat)   : alive_Select_858_src w  ⊑ alive_Select
 def alive_Select_859'_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%a : i1, %b : i1):
-  %v1 = "llvm.mlir.constant" () { value = -1 : i1 } :() -> (i1)
-  %v2 = "llvm.xor" (%a,%v1) : (i1, i1) -> (i1)
-  %v3 = "llvm.select" (%a,%b,%v2) : (i1, i1, i1) -> (i1)
-  "llvm.return" (%v3) : (i1) -> ()
+  %v1 = llvm.mlir.constant -1 :  i1
+  %v2 = llvm.xor %a, %v1 : i1
+  %v3 = llvm.select %a,%b, %v2 : i1, i1
+  llvm.return %v3 : i1
 }]
 
 def alive_Select_859'_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%a : _, %b : _):
-  %v1 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v2 = "llvm.xor" (%a,%v1) : (_, _) -> (_)
-  %v3 = "llvm.or" (%v2,%b) : (_, _) -> (_)
-  "llvm.return" (%v3) : (_) -> ()
+  %v1 = llvm.mlir.constant -1
+  %v2 = llvm.xor %a, %v1
+  %v3 = llvm.or %v2, %b
+  llvm.return %v3
 }]
 theorem alive_Select_859'  (w : Nat)   : alive_Select_859'_src w  ⊑ alive_Select_859'_tgt 1  := by
   unfold alive_Select_859'_src alive_Select_859'_tgt
@@ -3212,16 +3212,16 @@ theorem alive_Select_859'  (w : Nat)   : alive_Select_859'_src w  ⊑ alive_Sele
 def alive_Select_1100_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.mlir.constant" () { value = 1 : i1 } :() -> (i1)
-  %v2 = "llvm.select" (%v1,%X,%Y) : (i1, _, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.mlir.constant 1 :  i1
+  %v2 = llvm.select %v1,%X, %Y : i1, _
+  llvm.return %v2
 }]
 
 def alive_Select_1100_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.copy" (%X) : (_) -> (_)
-  "llvm.return" (%v1) : (_) -> ()
+  %v1 = llvm.copy %X
+  llvm.return %v1
 }]
 theorem alive_Select_1100  (w : Nat)   : alive_Select_1100_src w  ⊑ alive_Select_1100_tgt w  := by
   unfold alive_Select_1100_src alive_Select_1100_tgt
@@ -3241,16 +3241,16 @@ theorem alive_Select_1100  (w : Nat)   : alive_Select_1100_src w  ⊑ alive_Sele
 def alive_Select_1105_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.mlir.constant" () { value = 0 : i1 } :() -> (i1)
-  %v2 = "llvm.select" (%v1,%X,%Y) : (i1, _, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.mlir.constant 0 :  i1
+  %v2 = llvm.select %v1,%X, %Y : i1, _
+  llvm.return %v2
 }]
 
 def alive_Select_1105_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _):
-  %v1 = "llvm.copy" (%Y) : (_) -> (_)
-  "llvm.return" (%v1) : (_) -> ()
+  %v1 = llvm.copy %Y
+  llvm.return %v1
 }]
 theorem alive_Select_1105  (w : Nat)   : alive_Select_1105_src w  ⊑ alive_Select_1105_tgt w  := by
   unfold alive_Select_1105_src alive_Select_1105_tgt
@@ -3272,19 +3272,19 @@ theorem alive_Select_1105  (w : Nat)   : alive_Select_1105_src w  ⊑ alive_Sele
 def alive_InstCombineShift__239_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _):
-  %v1 = "llvm.shl" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.lshr" (%v1,%C) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.shl %X, %C
+  %v2 = llvm.lshr %v1, %C
+  llvm.return %v2
 }]
 
 def alive_InstCombineShift__239_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _):
-  %v1 = "llvm.shl" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.lshr" (%v2,%C) : (_, _) -> (_)
-  %v4 = "llvm.and" (%X,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.shl %X, %C
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.lshr %v2, %C
+  %v4 = llvm.and %X, %v3
+  llvm.return %v4
 }]
 theorem alive_InstCombineShift__239  (w : Nat)   : alive_InstCombineShift__239_src w  ⊑ alive_InstCombineShift__239_tgt w  := by
   unfold alive_InstCombineShift__239_src alive_InstCombineShift__239_tgt
@@ -3306,19 +3306,19 @@ theorem alive_InstCombineShift__239  (w : Nat)   : alive_InstCombineShift__239_s
 def alive_InstCombineShift__279_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _):
-  %v1 = "llvm.lshr" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.shl" (%v1,%C) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.lshr %X, %C
+  %v2 = llvm.shl %v1, %C
+  llvm.return %v2
 }]
 
 def alive_InstCombineShift__279_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _):
-  %v1 = "llvm.lshr" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.shl" (%v2,%C) : (_, _) -> (_)
-  %v4 = "llvm.and" (%X,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.lshr %X, %C
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.shl %v2, %C
+  %v4 = llvm.and %X, %v3
+  llvm.return %v4
 }]
 theorem alive_InstCombineShift__279  (w : Nat)   : alive_InstCombineShift__279_src w  ⊑ alive_InstCombineShift__279_tgt w  := by
   unfold alive_InstCombineShift__279_src alive_InstCombineShift__279_tgt
@@ -3346,25 +3346,25 @@ theorem alive_InstCombineShift__279  (w : Nat)   : alive_InstCombineShift__279_s
 def alive_InstCombineShift__440_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _, %C : _, %C2 : _):
-  %v1 = "llvm.lshr" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%C2) : (_, _) -> (_)
-  %v3 = "llvm.xor" (%Y,%v2) : (_, _) -> (_)
-  %v4 = "llvm.shl" (%v3,%C) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.lshr %X, %C
+  %v2 = llvm.and %v1, %C2
+  %v3 = llvm.xor %Y, %v2
+  %v4 = llvm.shl %v3, %C
+  llvm.return %v4
 }]
 
 set_option maxHeartbeats 400000 in
 def alive_InstCombineShift__440_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _, %C : _, %C2 : _):
-  %v1 = "llvm.shl" (%C2,%C) : (_, _) -> (_)
-  %v2 = "llvm.and" (%X,%v1) : (_, _) -> (_)
-  %v3 = "llvm.shl" (%Y,%C) : (_, _) -> (_)
-  %v4 = "llvm.lshr" (%X,%C) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v4,%C2) : (_, _) -> (_)
-  %v6 = "llvm.xor" (%Y,%v5) : (_, _) -> (_)
-  %v7 = "llvm.xor" (%v2,%v3) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.shl %C2, %C
+  %v2 = llvm.and %X, %v1
+  %v3 = llvm.shl %Y, %C
+  %v4 = llvm.lshr %X, %C
+  %v5 = llvm.and %v4, %C2
+  %v6 = llvm.xor %Y, %v5
+  %v7 = llvm.xor %v2, %v3
+  llvm.return %v7
 }]
 theorem alive_InstCombineShift__440  (w : Nat)   : alive_InstCombineShift__440_src w  ⊑ alive_InstCombineShift__440_tgt w  := by
   unfold alive_InstCombineShift__440_src alive_InstCombineShift__440_tgt
@@ -3392,25 +3392,25 @@ theorem alive_InstCombineShift__440  (w : Nat)   : alive_InstCombineShift__440_s
 def alive_InstCombineShift__476_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _, %C : _, %C2 : _):
-  %v1 = "llvm.lshr" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.and" (%v1,%C2) : (_, _) -> (_)
-  %v3 = "llvm.or" (%v2,%Y) : (_, _) -> (_)
-  %v4 = "llvm.shl" (%v3,%C) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.lshr %X, %C
+  %v2 = llvm.and %v1, %C2
+  %v3 = llvm.or %v2, %Y
+  %v4 = llvm.shl %v3, %C
+  llvm.return %v4
 }]
 
 set_option maxHeartbeats 400000 in
 def alive_InstCombineShift__476_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%Y : _, %X : _, %C : _, %C2 : _):
-  %v1 = "llvm.shl" (%Y,%C) : (_, _) -> (_)
-  %v2 = "llvm.shl" (%C2,%C) : (_, _) -> (_)
-  %v3 = "llvm.and" (%X,%v2) : (_, _) -> (_)
-  %v4 = "llvm.lshr" (%X,%C) : (_, _) -> (_)
-  %v5 = "llvm.and" (%v4,%C2) : (_, _) -> (_)
-  %v6 = "llvm.or" (%v5,%Y) : (_, _) -> (_)
-  %v7 = "llvm.or" (%v3,%v1) : (_, _) -> (_)
-  "llvm.return" (%v7) : (_) -> ()
+  %v1 = llvm.shl %Y, %C
+  %v2 = llvm.shl %C2, %C
+  %v3 = llvm.and %X, %v2
+  %v4 = llvm.lshr %X, %C
+  %v5 = llvm.and %v4, %C2
+  %v6 = llvm.or %v5, %Y
+  %v7 = llvm.or %v3, %v1
+  llvm.return %v7
 }]
 theorem alive_InstCombineShift__476  (w : Nat)   : alive_InstCombineShift__476_src w  ⊑ alive_InstCombineShift__476_tgt w  := by
   unfold alive_InstCombineShift__476_src alive_InstCombineShift__476_tgt
@@ -3433,19 +3433,19 @@ theorem alive_InstCombineShift__476  (w : Nat)   : alive_InstCombineShift__476_s
 def alive_InstCombineShift__497_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
-  %v1 = "llvm.xor" (%X,%C2) : (_, _) -> (_)
-  %v2 = "llvm.lshr" (%v1,%C) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.xor %X, %C2
+  %v2 = llvm.lshr %v1, %C
+  llvm.return %v2
 }]
 
 def alive_InstCombineShift__497_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
-  %v1 = "llvm.lshr" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.xor" (%X,%C2) : (_, _) -> (_)
-  %v3 = "llvm.lshr" (%C2,%C) : (_, _) -> (_)
-  %v4 = "llvm.xor" (%v1,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.lshr %X, %C
+  %v2 = llvm.xor %X, %C2
+  %v3 = llvm.lshr %C2, %C
+  %v4 = llvm.xor %v1, %v3
+  llvm.return %v4
 }]
 theorem alive_InstCombineShift__497  (w : Nat)   : alive_InstCombineShift__497_src w  ⊑ alive_InstCombineShift__497_tgt w  := by
   unfold alive_InstCombineShift__497_src alive_InstCombineShift__497_tgt
@@ -3468,19 +3468,19 @@ theorem alive_InstCombineShift__497  (w : Nat)   : alive_InstCombineShift__497_s
 def alive_InstCombineShift__497'''_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
-  %v1 = "llvm.add" (%X,%C2) : (_, _) -> (_)
-  %v2 = "llvm.shl" (%v1,%C) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.add %X, %C2
+  %v2 = llvm.shl %v1, %C
+  llvm.return %v2
 }]
 
 def alive_InstCombineShift__497'''_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
-  %v1 = "llvm.shl" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.add" (%X,%C2) : (_, _) -> (_)
-  %v3 = "llvm.shl" (%C2,%C) : (_, _) -> (_)
-  %v4 = "llvm.add" (%v1,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.shl %X, %C
+  %v2 = llvm.add %X, %C2
+  %v3 = llvm.shl %C2, %C
+  %v4 = llvm.add %v1, %v3
+  llvm.return %v4
 }]
 theorem alive_InstCombineShift__497'''  (w : Nat)   : alive_InstCombineShift__497'''_src w  ⊑ alive_InstCombineShift__497'''_tgt w  := by
   unfold alive_InstCombineShift__497'''_src alive_InstCombineShift__497'''_tgt
@@ -3502,19 +3502,19 @@ theorem alive_InstCombineShift__497'''  (w : Nat)   : alive_InstCombineShift__49
 def alive_InstCombineShift__582_src  (w : Nat)   :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _):
-  %v1 = "llvm.shl" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.lshr" (%v1,%C) : (_, _) -> (_)
-  "llvm.return" (%v2) : (_) -> ()
+  %v1 = llvm.shl %X, %C
+  %v2 = llvm.lshr %v1, %C
+  llvm.return %v2
 }]
 
 def alive_InstCombineShift__582_tgt  (w : Nat)  :=
 [alive_icom ( w )| {
 ^bb0(%X : _, %C : _):
-  %v1 = "llvm.shl" (%X,%C) : (_, _) -> (_)
-  %v2 = "llvm.mlir.constant" () { value = -1 : _ } :() -> (_)
-  %v3 = "llvm.lshr" (%v2,%C) : (_, _) -> (_)
-  %v4 = "llvm.and" (%X,%v3) : (_, _) -> (_)
-  "llvm.return" (%v4) : (_) -> ()
+  %v1 = llvm.shl %X, %C
+  %v2 = llvm.mlir.constant -1
+  %v3 = llvm.lshr %v2, %C
+  %v4 = llvm.and %X, %v3
+  llvm.return %v4
 }]
 theorem alive_InstCombineShift__582  (w : Nat)   : alive_InstCombineShift__582_src w  ⊑ alive_InstCombineShift__582_tgt w  := by
   unfold alive_InstCombineShift__582_src alive_InstCombineShift__582_tgt


### PR DESCRIPTION
This is factored out of https://github.com/opencompl/ssa/pull/369 and demonstrates that the actual syntax works. In a subsequent change, we need to auto-update the file via alive.

The following script was used for the update:

```bash

export FILES="AliveAutoGenerated.lean"

(cd SSA/Projects/InstCombine/; sed -e 's/LLVM.EDSL/LLVM.PrettyEDSL/' -i $FILES)
(cd SSA/Projects/InstCombine/; sed -e 's/= "\(llvm.mlir.constant\)" () { value = \(.*\) :\(.*\) } :() -> \(.*\)/= \1 \2 : \3/' -i $FILES)
(cd SSA/Projects/InstCombine/; sed -e 's/= "\(llvm.select\)" (\(.*\),\(.*\), \(.*\)) : (.*, \(.*\), .*) -> (.*)/= \1 \2, \3, \4 : \5/' -i $FILES)
(cd SSA/Projects/InstCombine/; sed -e 's/= "\(llvm..*\)" (\(.*\),\(.*\)) : (\(.*\),.*) -> .*/= \1 \2, \3 : \4/' -i $FILES)
(cd SSA/Projects/InstCombine/; sed -e 's/= "\(llvm..*\)" (\(.*\)) : (\(.*\)) -> (.*)/= \1 \2 : \3/' -i $FILES)
(cd SSA/Projects/InstCombine/; sed -e 's/"\(llvm.return\)" (\(.*\)) : (\(.*\)) -> (.*)/\1 \2 : \3/' -i $FILES)
(cd SSA/Projects/InstCombine/; sed -e 's/ : *_$//' -i $FILES)
```