### PR TITLE
chore: rename alive_icom to llvm

### DIFF
--- a/SSA/Projects/InstCombine/AliveAutoGenerated.lean
+++ b/SSA/Projects/InstCombine/AliveAutoGenerated.lean
@@ -35,7 +35,7 @@ set_option linter.deprecated false
 
 -/
 def alive_AddSub_1043_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _, %RHS : _):
   %v1 = llvm.and %Z, %C1
   %v2 = llvm.xor %v1, %C1
@@ -46,7 +46,7 @@ def alive_AddSub_1043_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1043_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _, %RHS : _):
   %v1 = llvm.not %C1
   %v2 = llvm.or %Z, %v1
@@ -73,14 +73,14 @@ theorem alive_AddSub_1043  (w : Nat)   : alive_AddSub_1043_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1152_src   :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%y : i1, %x : i1):
   %v1 = llvm.add %x, %y : i1
   llvm.return %v1 : i1
 }]
 
 def alive_AddSub_1152_tgt  :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%y : i1, %x : i1):
   %v1 = llvm.xor %x, %y : i1
   llvm.return %v1 : i1
@@ -101,14 +101,14 @@ theorem alive_AddSub_1152   : alive_AddSub_1152_src ⊑ alive_AddSub_1152_tgt :=
 
 -/
 def alive_AddSub_1156_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%b : _):
   %v1 = llvm.add %b, %b
   llvm.return %v1
 }]
 
 def alive_AddSub_1156_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%b : _):
   %v1 = llvm.mlir.constant 1
   %v2 = llvm.shl %b, %v1
@@ -132,7 +132,7 @@ theorem alive_AddSub_1156  (w : Nat)   : alive_AddSub_1156_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1164_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %a
@@ -141,7 +141,7 @@ def alive_AddSub_1164_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1164_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %a
@@ -169,7 +169,7 @@ theorem alive_AddSub_1164  (w : Nat)   : alive_AddSub_1164_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1165_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %a
@@ -180,7 +180,7 @@ def alive_AddSub_1165_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1165_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.add %a, %b
   %v2 = llvm.mlir.constant 0
@@ -209,7 +209,7 @@ theorem alive_AddSub_1165  (w : Nat)   : alive_AddSub_1165_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1176_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %b
@@ -218,7 +218,7 @@ def alive_AddSub_1176_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1176_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %b
@@ -243,7 +243,7 @@ theorem alive_AddSub_1176  (w : Nat)   : alive_AddSub_1176_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1202_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %x, %v1
@@ -252,7 +252,7 @@ def alive_AddSub_1202_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1202_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %x, %v1
@@ -281,7 +281,7 @@ theorem alive_AddSub_1202  (w : Nat)   : alive_AddSub_1202_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1295_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.xor %a, %b
@@ -290,7 +290,7 @@ def alive_AddSub_1295_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1295_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.xor %a, %b
@@ -317,7 +317,7 @@ theorem alive_AddSub_1295  (w : Nat)   : alive_AddSub_1295_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1309_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.or %a, %b
@@ -326,7 +326,7 @@ def alive_AddSub_1309_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1309_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.or %a, %b
@@ -351,7 +351,7 @@ theorem alive_AddSub_1309  (w : Nat)   : alive_AddSub_1309_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1539_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %x : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %a
@@ -360,7 +360,7 @@ def alive_AddSub_1539_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1539_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %x : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %a
@@ -383,14 +383,14 @@ theorem alive_AddSub_1539  (w : Nat)   : alive_AddSub_1539_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1539_2_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.sub %x, %C
   llvm.return %v1
 }]
 
 def alive_AddSub_1539_2_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.neg %C
   %v2 = llvm.add %x, %v1
@@ -412,14 +412,14 @@ theorem alive_AddSub_1539_2  (w : Nat)   : alive_AddSub_1539_2_src w  ⊑ alive_
 
 -/
 def alive_AddSub_1556_src   :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%y : i1, %x : i1):
   %v1 = llvm.sub %x, %y : i1
   llvm.return %v1 : i1
 }]
 
 def alive_AddSub_1556_tgt  :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%y : i1, %x : i1):
   %v1 = llvm.xor %x, %y : i1
   llvm.return %v1 : i1
@@ -440,7 +440,7 @@ theorem alive_AddSub_1556   : alive_AddSub_1556_src ⊑ alive_AddSub_1556_tgt :=
 
 -/
 def alive_AddSub_1560_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.sub %v1, %a
@@ -448,7 +448,7 @@ def alive_AddSub_1560_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1560_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %a, %v1
@@ -472,7 +472,7 @@ theorem alive_AddSub_1560  (w : Nat)   : alive_AddSub_1560_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1564_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %x, %v1
@@ -481,7 +481,7 @@ def alive_AddSub_1564_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1564_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %x, %v1
@@ -508,7 +508,7 @@ theorem alive_AddSub_1564  (w : Nat)   : alive_AddSub_1564_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1574_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
   %v1 = llvm.add %X, %C2
   %v2 = llvm.sub %C, %v1
@@ -516,7 +516,7 @@ def alive_AddSub_1574_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1574_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
   %v1 = llvm.add %X, %C2
   %v2 = llvm.sub %C, %C2
@@ -541,7 +541,7 @@ theorem alive_AddSub_1574  (w : Nat)   : alive_AddSub_1574_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1614_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.add %X, %Y
   %v2 = llvm.sub %X, %v1
@@ -549,7 +549,7 @@ def alive_AddSub_1614_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1614_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.add %X, %Y
   %v2 = llvm.mlir.constant 0
@@ -574,7 +574,7 @@ theorem alive_AddSub_1614  (w : Nat)   : alive_AddSub_1614_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1619_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.sub %X, %Y
   %v2 = llvm.sub %v1, %X
@@ -582,7 +582,7 @@ def alive_AddSub_1619_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1619_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.sub %X, %Y
   %v2 = llvm.mlir.constant 0
@@ -609,7 +609,7 @@ theorem alive_AddSub_1619  (w : Nat)   : alive_AddSub_1619_src w  ⊑ alive_AddS
 
 -/
 def alive_AddSub_1624_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.or %A, %B
   %v2 = llvm.xor %A, %B
@@ -618,7 +618,7 @@ def alive_AddSub_1624_src  (w : Nat)   :=
 }]
 
 def alive_AddSub_1624_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.or %A, %B
   %v2 = llvm.xor %A, %B
@@ -644,7 +644,7 @@ theorem alive_AddSub_1624  (w : Nat)   : alive_AddSub_1624_src w  ⊑ alive_AddS
 
 -/
 def alive_AndOrXor_135_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C1 : _, %C2 : _):
   %v1 = llvm.xor %X, %C1
   %v2 = llvm.and %v1, %C2
@@ -652,7 +652,7 @@ def alive_AndOrXor_135_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_135_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C1 : _, %C2 : _):
   %v1 = llvm.and %X, %C2
   %v2 = llvm.xor %X, %C1
@@ -679,7 +679,7 @@ theorem alive_AndOrXor_135  (w : Nat)   : alive_AndOrXor_135_src w  ⊑ alive_An
 
 -/
 def alive_AndOrXor_144_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C1 : _, %C2 : _):
   %v1 = llvm.or %X, %C1
   %v2 = llvm.and %v1, %C2
@@ -687,7 +687,7 @@ def alive_AndOrXor_144_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_144_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C1 : _, %C2 : _):
   %v1 = llvm.and %C1, %C2
   %v2 = llvm.or %X, %v1
@@ -723,7 +723,7 @@ theorem alive_AndOrXor_144  (w : Nat)   : alive_AndOrXor_144_src w  ⊑ alive_An
 -- MANUAL FIX: the translation script inferred some of the resulting types to be `i1`
 -- where they should be the meta-variable `_` (https://github.com/opencompl/ssa/issues/169)
 def alive_AndOrXor_698_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.and %a, %d
@@ -736,7 +736,7 @@ def alive_AndOrXor_698_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_698_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
   %v1 = llvm.or %b, %d
   %v2 = llvm.and %a, %v1
@@ -776,7 +776,7 @@ theorem alive_AndOrXor_698  (w : Nat)   : alive_AndOrXor_698_src w  ⊑ alive_An
 
 -/
 def alive_AndOrXor_709_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.and %a, %d
@@ -787,7 +787,7 @@ def alive_AndOrXor_709_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_709_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
   %v1 = llvm.or %b, %d
   %v2 = llvm.and %a, %v1
@@ -824,7 +824,7 @@ theorem alive_AndOrXor_709  (w : Nat)   : alive_AndOrXor_709_src w  ⊑ alive_An
 
 -/
 def alive_AndOrXor_716_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.and %a, %d
@@ -835,7 +835,7 @@ def alive_AndOrXor_716_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_716_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _, %d : _):
   %v1 = llvm.and %b, %d
   %v2 = llvm.and %a, %v1
@@ -866,7 +866,7 @@ theorem alive_AndOrXor_716  (w : Nat)   : alive_AndOrXor_716_src w  ⊑ alive_An
 
 -/
 def alive_AndOrXor_794_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.icmp.sgt %a, %b
   %v2 = llvm.icmp.ne %a, %b
@@ -875,7 +875,7 @@ def alive_AndOrXor_794_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_794_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.icmp.sgt %a, %b
   %v2 = llvm.icmp.ne %a, %b
@@ -904,7 +904,7 @@ theorem alive_AndOrXor_794  (w : Nat)   : alive_AndOrXor_794_src w  ⊑ alive_An
 -/
 -- MANUAL FIX (https://github.com/opencompl/ssa/issues/169)
 def alive_AndOrXor_827_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.icmp.eq %a, %v1
@@ -915,7 +915,7 @@ def alive_AndOrXor_827_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_827_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.or %a, %b
   %v2 = llvm.mlir.constant 0
@@ -946,7 +946,7 @@ theorem alive_AndOrXor_827  (w : Nat)   : alive_AndOrXor_827_src w  ⊑ alive_An
 
 -/
 def alive_AndOrXor_887_2_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %C1 : _):
   %v1 = llvm.icmp.eq %a, %C1
   %v2 = llvm.icmp.ne %a, %C1
@@ -955,7 +955,7 @@ def alive_AndOrXor_887_2_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_887_2_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %C1 : _):
   %v1 = llvm.icmp.eq %a, %C1
   %v2 = llvm.icmp.ne %a, %C1
@@ -984,7 +984,7 @@ theorem alive_AndOrXor_887_2  (w : Nat)   : alive_AndOrXor_887_2_src w  ⊑ aliv
 
 -/
 def alive_AndOrXor_1230__A__B___A__B_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%notOp0 : _, %notOp1 : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %notOp0, %v1
@@ -995,7 +995,7 @@ def alive_AndOrXor_1230__A__B___A__B_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1230__A__B___A__B_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%notOp0 : _, %notOp1 : _):
   %v1 = llvm.or %notOp0, %notOp1
   %v2 = llvm.mlir.constant -1
@@ -1028,7 +1028,7 @@ theorem alive_AndOrXor_1230__A__B___A__B  (w : Nat)   : alive_AndOrXor_1230__A__
 
 -/
 def alive_AndOrXor_1241_AB__AB__AB_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.or %A, %B
   %v2 = llvm.and %A, %B
@@ -1039,7 +1039,7 @@ def alive_AndOrXor_1241_AB__AB__AB_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1241_AB__AB__AB_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.or %A, %B
   %v2 = llvm.and %A, %B
@@ -1070,7 +1070,7 @@ theorem alive_AndOrXor_1241_AB__AB__AB  (w : Nat)   : alive_AndOrXor_1241_AB__AB
 
 -/
 def alive_AndOrXor_1247_AB__AB__AB_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.and %A, %B
   %v2 = llvm.mlir.constant -1
@@ -1081,7 +1081,7 @@ def alive_AndOrXor_1247_AB__AB__AB_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1247_AB__AB__AB_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.and %A, %B
   %v2 = llvm.mlir.constant -1
@@ -1109,7 +1109,7 @@ theorem alive_AndOrXor_1247_AB__AB__AB  (w : Nat)   : alive_AndOrXor_1247_AB__AB
 
 -/
 def alive_AndOrXor_1253_A__AB___A__B_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.xor %A, %B
   %v2 = llvm.and %v1, %A
@@ -1117,7 +1117,7 @@ def alive_AndOrXor_1253_A__AB___A__B_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1253_A__AB___A__B_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %B, %v1
@@ -1145,7 +1145,7 @@ theorem alive_AndOrXor_1253_A__AB___A__B  (w : Nat)   : alive_AndOrXor_1253_A__A
 
 -/
 def alive_AndOrXor_1280_ABA___AB_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %A, %v1
@@ -1155,7 +1155,7 @@ def alive_AndOrXor_1280_ABA___AB_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1280_ABA___AB_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %A, %v1
@@ -1186,7 +1186,7 @@ theorem alive_AndOrXor_1280_ABA___AB  (w : Nat)   : alive_AndOrXor_1280_ABA___AB
 
 -/
 def alive_AndOrXor_1288_A__B__B__C__A___A__B__C_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
   %v1 = llvm.xor %A, %B
   %v2 = llvm.xor %B, %C
@@ -1196,7 +1196,7 @@ def alive_AndOrXor_1288_A__B__B__C__A___A__B__C_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1288_A__B__B__C__A___A__B__C_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
   %v1 = llvm.xor %A, %B
   %v2 = llvm.mlir.constant -1
@@ -1228,7 +1228,7 @@ theorem alive_AndOrXor_1288_A__B__B__C__A___A__B__C  (w : Nat)   : alive_AndOrXo
 
 -/
 def alive_AndOrXor_1294_A__B__A__B___A__B_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.or %A, %B
   %v2 = llvm.mlir.constant -1
@@ -1239,7 +1239,7 @@ def alive_AndOrXor_1294_A__B__A__B___A__B_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1294_A__B__A__B___A__B_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.or %A, %B
   %v2 = llvm.mlir.constant -1
@@ -1268,7 +1268,7 @@ theorem alive_AndOrXor_1294_A__B__A__B___A__B  (w : Nat)   : alive_AndOrXor_1294
 
 -/
 def alive_AndOrXor_1683_1_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.icmp.ugt %a, %b
   %v2 = llvm.icmp.eq %a, %b
@@ -1277,7 +1277,7 @@ def alive_AndOrXor_1683_1_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1683_1_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.icmp.ugt %a, %b
   %v2 = llvm.icmp.eq %a, %b
@@ -1304,7 +1304,7 @@ theorem alive_AndOrXor_1683_1  (w : Nat)   : alive_AndOrXor_1683_1_src w  ⊑ al
 
 -/
 def alive_AndOrXor_1683_2_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.icmp.uge %a, %b
   %v2 = llvm.icmp.ne %a, %b
@@ -1313,7 +1313,7 @@ def alive_AndOrXor_1683_2_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1683_2_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.icmp.uge %a, %b
   %v2 = llvm.icmp.ne %a, %b
@@ -1343,7 +1343,7 @@ theorem alive_AndOrXor_1683_2  (w : Nat)   : alive_AndOrXor_1683_2_src w  ⊑ al
 -/
 -- MANUAL FIX (https://github.com/opencompl/ssa/issues/169)
 def alive_AndOrXor_1704_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.icmp.eq %B, %v1
@@ -1353,7 +1353,7 @@ def alive_AndOrXor_1704_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1704_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.add %B, %v1
@@ -1385,7 +1385,7 @@ theorem alive_AndOrXor_1704  (w : Nat)   : alive_AndOrXor_1704_src w  ⊑ alive_
 -/
 -- MANUAL FIX (https://github.com/opencompl/ssa/issues/169)
 def alive_AndOrXor_1705_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.icmp.eq %B, %v1
@@ -1395,7 +1395,7 @@ def alive_AndOrXor_1705_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1705_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.add %B, %v1
@@ -1427,7 +1427,7 @@ theorem alive_AndOrXor_1705  (w : Nat)   : alive_AndOrXor_1705_src w  ⊑ alive_
 -/
 -- MANUAL FIX (https://github.com/opencompl/ssa/issues/169)
 def alive_AndOrXor_1733_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.icmp.ne %A, %v1
@@ -1438,7 +1438,7 @@ def alive_AndOrXor_1733_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_1733_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.or %A, %B
   %v2 = llvm.mlir.constant 0
@@ -1468,7 +1468,7 @@ theorem alive_AndOrXor_1733  (w : Nat)   : alive_AndOrXor_1733_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C1 : _, %C : _):
   %v1 = llvm.xor %x, %C1
   %v2 = llvm.or %v1, %C
@@ -1476,7 +1476,7 @@ def alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C1 : _, %C : _):
   %v1 = llvm.or %x, %C
   %v2 = llvm.xor %x, %C1
@@ -1505,7 +1505,7 @@ theorem alive_AndOrXor_2063__X__C1__C2____X__C2__C1__C2  (w : Nat)   : alive_And
 
 -/
 def alive_AndOrXor_2113___A__B__A___A__B_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %A, %v1
@@ -1515,7 +1515,7 @@ def alive_AndOrXor_2113___A__B__A___A__B_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2113___A__B__A___A__B_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %A, %v1
@@ -1543,7 +1543,7 @@ theorem alive_AndOrXor_2113___A__B__A___A__B  (w : Nat)   : alive_AndOrXor_2113_
 
 -/
 def alive_AndOrXor_2118___A__B__A___A__B_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %A, %v1
@@ -1553,7 +1553,7 @@ def alive_AndOrXor_2118___A__B__A___A__B_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2118___A__B__A___A__B_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %A, %v1
@@ -1583,7 +1583,7 @@ theorem alive_AndOrXor_2118___A__B__A___A__B  (w : Nat)   : alive_AndOrXor_2118_
 
 -/
 def alive_AndOrXor_2123___A__B__A__B___A__B_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %B, %v1
@@ -1594,7 +1594,7 @@ def alive_AndOrXor_2123___A__B__A__B___A__B_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2123___A__B__A__B___A__B_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %B, %v1
@@ -1627,7 +1627,7 @@ theorem alive_AndOrXor_2123___A__B__A__B___A__B  (w : Nat)   : alive_AndOrXor_21
 
 -/
 def alive_AndOrXor_2188_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %D : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %D, %v1
@@ -1640,7 +1640,7 @@ def alive_AndOrXor_2188_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2188_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %D : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %D, %v1
@@ -1673,7 +1673,7 @@ theorem alive_AndOrXor_2188  (w : Nat)   : alive_AndOrXor_2188_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2231__A__B__B__C__A___A__B__C_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
   %v1 = llvm.xor %A, %B
   %v2 = llvm.xor %B, %C
@@ -1683,7 +1683,7 @@ def alive_AndOrXor_2231__A__B__B__C__A___A__B__C_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2231__A__B__B__C__A___A__B__C_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
   %v1 = llvm.xor %A, %B
   %v2 = llvm.xor %B, %C
@@ -1712,7 +1712,7 @@ theorem alive_AndOrXor_2231__A__B__B__C__A___A__B__C  (w : Nat)   : alive_AndOrX
 
 -/
 def alive_AndOrXor_2243__B__C__A__B___B__A__C_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
   %v1 = llvm.or %B, %C
   %v2 = llvm.and %v1, %A
@@ -1721,7 +1721,7 @@ def alive_AndOrXor_2243__B__C__A__B___B__A__C_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2243__B__C__A__B___B__A__C_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %C : _, %B : _):
   %v1 = llvm.and %A, %C
   %v2 = llvm.or %B, %C
@@ -1750,7 +1750,7 @@ theorem alive_AndOrXor_2243__B__C__A__B___B__A__C  (w : Nat)   : alive_AndOrXor_
 
 -/
 def alive_AndOrXor_2247__A__B__A__B_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %A, %v1
@@ -1761,7 +1761,7 @@ def alive_AndOrXor_2247__A__B__A__B_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2247__A__B__A__B_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.and %A, %B
   %v2 = llvm.mlir.constant -1
@@ -1790,7 +1790,7 @@ theorem alive_AndOrXor_2247__A__B__A__B  (w : Nat)   : alive_AndOrXor_2247__A__B
 
 -/
 def alive_AndOrXor_2263_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%B : _, %op0 : _):
   %v1 = llvm.xor %op0, %B
   %v2 = llvm.or %op0, %v1
@@ -1798,7 +1798,7 @@ def alive_AndOrXor_2263_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2263_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%B : _, %op0 : _):
   %v1 = llvm.xor %op0, %B
   %v2 = llvm.or %op0, %B
@@ -1825,7 +1825,7 @@ theorem alive_AndOrXor_2263  (w : Nat)   : alive_AndOrXor_2263_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2264_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %A, %v1
@@ -1835,7 +1835,7 @@ def alive_AndOrXor_2264_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2264_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %B, %v1
@@ -1865,7 +1865,7 @@ theorem alive_AndOrXor_2264  (w : Nat)   : alive_AndOrXor_2264_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2265_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.and %A, %B
   %v2 = llvm.xor %A, %B
@@ -1874,7 +1874,7 @@ def alive_AndOrXor_2265_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2265_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.and %A, %B
   %v2 = llvm.xor %A, %B
@@ -1902,7 +1902,7 @@ theorem alive_AndOrXor_2265  (w : Nat)   : alive_AndOrXor_2265_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2284_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.or %A, %B
   %v2 = llvm.mlir.constant -1
@@ -1912,7 +1912,7 @@ def alive_AndOrXor_2284_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2284_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %B, %v1
@@ -1943,7 +1943,7 @@ theorem alive_AndOrXor_2284  (w : Nat)   : alive_AndOrXor_2284_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2285_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.xor %A, %B
   %v2 = llvm.mlir.constant -1
@@ -1953,7 +1953,7 @@ def alive_AndOrXor_2285_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2285_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %B, %v1
@@ -1985,7 +1985,7 @@ theorem alive_AndOrXor_2285  (w : Nat)   : alive_AndOrXor_2285_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2297_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.and %A, %B
   %v2 = llvm.mlir.constant -1
@@ -1996,7 +1996,7 @@ def alive_AndOrXor_2297_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2297_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %B : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %A, %v1
@@ -2024,7 +2024,7 @@ theorem alive_AndOrXor_2297  (w : Nat)   : alive_AndOrXor_2297_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2367_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %C1 : _, %op1 : _):
   %v1 = llvm.or %A, %C1
   %v2 = llvm.or %v1, %op1
@@ -2032,7 +2032,7 @@ def alive_AndOrXor_2367_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2367_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%A : _, %C1 : _, %op1 : _):
   %v1 = llvm.or %A, %op1
   %v2 = llvm.or %A, %C1
@@ -2060,7 +2060,7 @@ theorem alive_AndOrXor_2367  (w : Nat)   : alive_AndOrXor_2367_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2416_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%nx : _, %y : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %nx, %v1
@@ -2071,7 +2071,7 @@ def alive_AndOrXor_2416_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2416_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%nx : _, %y : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %y, %v1
@@ -2102,7 +2102,7 @@ theorem alive_AndOrXor_2416  (w : Nat)   : alive_AndOrXor_2416_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2417_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%nx : _, %y : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %nx, %v1
@@ -2113,7 +2113,7 @@ def alive_AndOrXor_2417_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2417_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%nx : _, %y : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %y, %v1
@@ -2143,7 +2143,7 @@ theorem alive_AndOrXor_2417  (w : Nat)   : alive_AndOrXor_2417_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2429_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%y : _, %x : _):
   %v1 = llvm.and %x, %y
   %v2 = llvm.mlir.constant -1
@@ -2152,7 +2152,7 @@ def alive_AndOrXor_2429_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2429_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%y : _, %x : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %x, %v1
@@ -2182,7 +2182,7 @@ theorem alive_AndOrXor_2429  (w : Nat)   : alive_AndOrXor_2429_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2430_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%y : _, %x : _):
   %v1 = llvm.or %x, %y
   %v2 = llvm.mlir.constant -1
@@ -2191,7 +2191,7 @@ def alive_AndOrXor_2430_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2430_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%y : _, %x : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %x, %v1
@@ -2221,7 +2221,7 @@ theorem alive_AndOrXor_2430  (w : Nat)   : alive_AndOrXor_2430_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2443_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%y : _, %x : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %x, %v1
@@ -2232,7 +2232,7 @@ def alive_AndOrXor_2443_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2443_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%y : _, %x : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %x, %v1
@@ -2259,7 +2259,7 @@ theorem alive_AndOrXor_2443  (w : Nat)   : alive_AndOrXor_2443_src w  ⊑ alive_
 -/
 -- MANUAL FIX (https://github.com/opencompl/ssa/issues/169)
 def alive_AndOrXor_2453_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%y : _, %x : _):
   %v1 = llvm.icmp.slt %x, %y
   %v2 = llvm.mlir.constant -1 :  i1
@@ -2268,7 +2268,7 @@ def alive_AndOrXor_2453_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2453_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%y : _, %x : _):
   %v1 = llvm.icmp.slt %x, %y
   %v2 = llvm.icmp.sge %x, %y
@@ -2292,7 +2292,7 @@ theorem alive_AndOrXor_2453  (w : Nat)   : alive_AndOrXor_2453_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2475_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.sub %C, %x
   %v2 = llvm.mlir.constant -1
@@ -2301,7 +2301,7 @@ def alive_AndOrXor_2475_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2475_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.sub %C, %x
   %v2 = llvm.mlir.constant -1
@@ -2327,7 +2327,7 @@ theorem alive_AndOrXor_2475  (w : Nat)   : alive_AndOrXor_2475_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2486_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.add %x, %C
   %v2 = llvm.mlir.constant -1
@@ -2336,7 +2336,7 @@ def alive_AndOrXor_2486_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2486_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _, %C : _):
   %v1 = llvm.add %x, %C
   %v2 = llvm.mlir.constant -1
@@ -2363,7 +2363,7 @@ theorem alive_AndOrXor_2486  (w : Nat)   : alive_AndOrXor_2486_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2581__BAB___A__B_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %op1 : _):
   %v1 = llvm.or %a, %op1
   %v2 = llvm.xor %v1, %op1
@@ -2371,7 +2371,7 @@ def alive_AndOrXor_2581__BAB___A__B_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2581__BAB___A__B_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %op1 : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %op1, %v1
@@ -2398,7 +2398,7 @@ theorem alive_AndOrXor_2581__BAB___A__B  (w : Nat)   : alive_AndOrXor_2581__BAB_
 
 -/
 def alive_AndOrXor_2587__BAA___B__A_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %op1 : _):
   %v1 = llvm.and %a, %op1
   %v2 = llvm.xor %v1, %op1
@@ -2406,7 +2406,7 @@ def alive_AndOrXor_2587__BAA___B__A_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2587__BAA___B__A_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %op1 : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %a, %v1
@@ -2434,7 +2434,7 @@ theorem alive_AndOrXor_2587__BAA___B__A  (w : Nat)   : alive_AndOrXor_2587__BAA_
 
 -/
 def alive_AndOrXor_2595_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.or %a, %b
@@ -2443,7 +2443,7 @@ def alive_AndOrXor_2595_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2595_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.or %a, %b
@@ -2474,7 +2474,7 @@ theorem alive_AndOrXor_2595  (w : Nat)   : alive_AndOrXor_2595_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2607_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %a, %v1
@@ -2487,7 +2487,7 @@ def alive_AndOrXor_2607_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2607_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %a, %v1
@@ -2522,7 +2522,7 @@ theorem alive_AndOrXor_2607  (w : Nat)   : alive_AndOrXor_2607_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2617_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %a, %v1
@@ -2535,7 +2535,7 @@ def alive_AndOrXor_2617_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2617_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %a, %v1
@@ -2568,7 +2568,7 @@ theorem alive_AndOrXor_2617  (w : Nat)   : alive_AndOrXor_2617_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2627_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %c : _, %b : _):
   %v1 = llvm.xor %a, %c
   %v2 = llvm.or %a, %b
@@ -2577,7 +2577,7 @@ def alive_AndOrXor_2627_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2627_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %c : _, %b : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %a, %v1
@@ -2607,7 +2607,7 @@ theorem alive_AndOrXor_2627  (w : Nat)   : alive_AndOrXor_2627_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2647_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.xor %a, %b
@@ -2616,7 +2616,7 @@ def alive_AndOrXor_2647_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2647_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.xor %a, %b
@@ -2646,7 +2646,7 @@ theorem alive_AndOrXor_2647  (w : Nat)   : alive_AndOrXor_2647_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2658_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %b, %v1
@@ -2658,7 +2658,7 @@ def alive_AndOrXor_2658_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2658_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.and %a, %b
   %v2 = llvm.mlir.constant -1
@@ -2690,7 +2690,7 @@ theorem alive_AndOrXor_2658  (w : Nat)   : alive_AndOrXor_2658_src w  ⊑ alive_
 
 -/
 def alive_AndOrXor_2663_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.icmp.ule %a, %b
   %v2 = llvm.icmp.ne %a, %b
@@ -2699,7 +2699,7 @@ def alive_AndOrXor_2663_src  (w : Nat)   :=
 }]
 
 def alive_AndOrXor_2663_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.icmp.ule %a, %b
   %v2 = llvm.icmp.ne %a, %b
@@ -2722,7 +2722,7 @@ theorem alive_AndOrXor_2663  (w : Nat)   : alive_AndOrXor_2663_src w  ⊑ alive_
 
 -/
 def alive_152_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.mul %x, %v1
@@ -2730,7 +2730,7 @@ def alive_152_src  (w : Nat)   :=
 }]
 
 def alive_152_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%x : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %x
@@ -2756,7 +2756,7 @@ theorem alive_152  (w : Nat)   : alive_152_src w  ⊑ alive_152_tgt w  := by
 
 -/
 def alive_229_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C1 : _, %Op1 : _):
   %v1 = llvm.add %X, %C1
   %v2 = llvm.mul %v1, %Op1
@@ -2764,7 +2764,7 @@ def alive_229_src  (w : Nat)   :=
 }]
 
 def alive_229_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C1 : _, %Op1 : _):
   %v1 = llvm.mul %C1, %Op1
   %v2 = llvm.mul %X, %Op1
@@ -2792,7 +2792,7 @@ theorem alive_229  (w : Nat)   : alive_229_src w  ⊑ alive_229_tgt w  := by
 
 -/
 def alive_239_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %X
@@ -2803,7 +2803,7 @@ def alive_239_src  (w : Nat)   :=
 }]
 
 def alive_239_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %X
@@ -2831,7 +2831,7 @@ theorem alive_239  (w : Nat)   : alive_239_src w  ⊑ alive_239_tgt w  := by
 
 -/
 def alive_275_src   :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%Y : i5, %X : i5):
   %v1 = llvm.udiv %X, %Y : i5
   %v2 = llvm.mul %v1, %Y : i5
@@ -2839,7 +2839,7 @@ def alive_275_src   :=
 }]
 
 def alive_275_tgt  :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%Y : i5, %X : i5):
   %v1 = llvm.urem %X, %Y : i5
   %v2 = llvm.udiv %X, %Y : i5
@@ -2865,7 +2865,7 @@ theorem alive_275   : alive_275_src ⊑ alive_275_tgt := by
 
 -/
 def alive_275_2_src   :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%Y : i5, %X : i5):
   %v1 = llvm.sdiv %X, %Y : i5
   %v2 = llvm.mul %v1, %Y : i5
@@ -2873,7 +2873,7 @@ def alive_275_2_src   :=
 }]
 
 def alive_275_2_tgt  :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%Y : i5, %X : i5):
   %v1 = llvm.srem %X, %Y : i5
   %v2 = llvm.sdiv %X, %Y : i5
@@ -2902,7 +2902,7 @@ theorem alive_275_2   : alive_275_2_src ⊑ alive_275_2_tgt := by
 -/
 -- MANUAL FIX: https://github.com/opencompl/ssa/issues/169
 def alive_276_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : i5, %X : i5):
   %v1 = llvm.sdiv %X, %Y : i5
   %v2 = llvm.mlir.constant 0 :  i5
@@ -2912,7 +2912,7 @@ def alive_276_src  (w : Nat)   :=
 }]
 
 def alive_276_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : i5, %X : i5):
   %v1 = llvm.srem %X, %Y : i5
   %v2 = llvm.sdiv %X, %Y : i5
@@ -2943,7 +2943,7 @@ theorem alive_276  (w : Nat)   : alive_276_src w  ⊑ alive_276_tgt w  := by
 -/
 -- MANUAL FIX: https://github.com/opencompl/ssa/issues/169
 def alive_276_2_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : i5, %X : i5):
   %v1 = llvm.udiv %X, %Y : i5
   %v2 = llvm.mlir.constant 0 :  i5
@@ -2953,7 +2953,7 @@ def alive_276_2_src  (w : Nat)   :=
 }]
 
 def alive_276_2_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : i5, %X : i5):
   %v1 = llvm.urem %X, %Y : i5
   %v2 = llvm.udiv %X, %Y : i5
@@ -2978,14 +2978,14 @@ theorem alive_276_2  (w : Nat)   : alive_276_2_src w  ⊑ alive_276_2_tgt w  := 
 
 -/
 def alive_283_src   :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%Y : i1, %X : i1):
   %v1 = llvm.mul %X, %Y : i1
   llvm.return %v1 : i1
 }]
 
 def alive_283_tgt  :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%Y : i1, %X : i1):
   %v1 = llvm.and %X, %Y : i1
   llvm.return %v1 : i1
@@ -3008,7 +3008,7 @@ theorem alive_283   : alive_283_src ⊑ alive_283_tgt := by
 
 -/
 def alive_290__292_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %Op1 : _):
   %v1 = llvm.mlir.constant 1
   %v2 = llvm.shl %v1, %Y
@@ -3017,7 +3017,7 @@ def alive_290__292_src  (w : Nat)   :=
 }]
 
 def alive_290__292_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %Op1 : _):
   %v1 = llvm.mlir.constant 1
   %v2 = llvm.shl %v1, %Y
@@ -3044,7 +3044,7 @@ theorem alive_290__292  (w : Nat)   : alive_290__292_src w  ⊑ alive_290__292_t
 
 -/
 def alive_820_src   :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%X : i9, %Op1 : i9):
   %v1 = llvm.srem %X, %Op1 : i9
   %v2 = llvm.sub %X, %v1 : i9
@@ -3053,7 +3053,7 @@ def alive_820_src   :=
 }]
 
 def alive_820_tgt  :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%X : i9, %Op1 : i9):
   %v1 = llvm.srem %X, %Op1 : i9
   %v2 = llvm.sub %X, %v1 : i9
@@ -3080,7 +3080,7 @@ theorem alive_820   : alive_820_src ⊑ alive_820_tgt := by
 
 -/
 def alive_820'_src   :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%X : i9, %Op1 : i9):
   %v1 = llvm.urem %X, %Op1 : i9
   %v2 = llvm.sub %X, %v1 : i9
@@ -3089,7 +3089,7 @@ def alive_820'_src   :=
 }]
 
 def alive_820'_tgt  :=
-[alive_icom ()| {
+[llvm ()| {
 ^bb0(%X : i9, %Op1 : i9):
   %v1 = llvm.urem %X, %Op1 : i9
   %v2 = llvm.sub %X, %v1 : i9
@@ -3112,7 +3112,7 @@ theorem alive_820'   : alive_820'_src ⊑ alive_820'_tgt := by
 
 -/
 def alive_1030_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.sdiv %X, %v1
@@ -3120,7 +3120,7 @@ def alive_1030_src  (w : Nat)   :=
 }]
 
 def alive_1030_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _):
   %v1 = llvm.mlir.constant 0
   %v2 = llvm.sub %v1, %X
@@ -3145,7 +3145,7 @@ theorem alive_1030  (w : Nat)   : alive_1030_src w  ⊑ alive_1030_tgt w  := by
 -/
 -- MANUAL FIX (https://github.com/opencompl/ssa/issues/169)
 def alive_Select_858_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : i1, %b : i1):
   %v1 = llvm.mlir.constant -1 :  i1
   %v2 = llvm.xor %a, %v1 : i1
@@ -3154,7 +3154,7 @@ def alive_Select_858_src  (w : Nat)   :=
 }]
 
 def alive_Select_858_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %a, %v1
@@ -3179,7 +3179,7 @@ theorem alive_Select_858  (w : Nat)   : alive_Select_858_src w  ⊑ alive_Select
 -/
 -- MANUAL FIX (https://github.com/opencompl/ssa/issues/169)
 def alive_Select_859'_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : i1, %b : i1):
   %v1 = llvm.mlir.constant -1 :  i1
   %v2 = llvm.xor %a, %v1 : i1
@@ -3188,7 +3188,7 @@ def alive_Select_859'_src  (w : Nat)   :=
 }]
 
 def alive_Select_859'_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%a : _, %b : _):
   %v1 = llvm.mlir.constant -1
   %v2 = llvm.xor %a, %v1
@@ -3210,7 +3210,7 @@ theorem alive_Select_859'  (w : Nat)   : alive_Select_859'_src w ⊑ alive_Selec
 
 -/
 def alive_Select_1100_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.mlir.constant 1 :  i1
   %v2 = llvm.select %v1, %X, %Y
@@ -3218,7 +3218,7 @@ def alive_Select_1100_src  (w : Nat)   :=
 }]
 
 def alive_Select_1100_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.copy %X
   llvm.return %v1
@@ -3239,7 +3239,7 @@ theorem alive_Select_1100  (w : Nat)   : alive_Select_1100_src w  ⊑ alive_Sele
 
 -/
 def alive_Select_1105_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.mlir.constant 0 :  i1
   %v2 = llvm.select %v1,%X, %Y
@@ -3247,7 +3247,7 @@ def alive_Select_1105_src  (w : Nat)   :=
 }]
 
 def alive_Select_1105_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _):
   %v1 = llvm.copy %Y
   llvm.return %v1
@@ -3270,7 +3270,7 @@ theorem alive_Select_1105  (w : Nat)   : alive_Select_1105_src w  ⊑ alive_Sele
 
 -/
 def alive_InstCombineShift__239_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _):
   %v1 = llvm.shl %X, %C
   %v2 = llvm.lshr %v1, %C
@@ -3278,7 +3278,7 @@ def alive_InstCombineShift__239_src  (w : Nat)   :=
 }]
 
 def alive_InstCombineShift__239_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _):
   %v1 = llvm.shl %X, %C
   %v2 = llvm.mlir.constant -1
@@ -3304,7 +3304,7 @@ theorem alive_InstCombineShift__239  (w : Nat)   : alive_InstCombineShift__239_s
 
 -/
 def alive_InstCombineShift__279_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _):
   %v1 = llvm.lshr %X, %C
   %v2 = llvm.shl %v1, %C
@@ -3312,7 +3312,7 @@ def alive_InstCombineShift__279_src  (w : Nat)   :=
 }]
 
 def alive_InstCombineShift__279_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _):
   %v1 = llvm.lshr %X, %C
   %v2 = llvm.mlir.constant -1
@@ -3344,7 +3344,7 @@ theorem alive_InstCombineShift__279  (w : Nat)   : alive_InstCombineShift__279_s
 
 -/
 def alive_InstCombineShift__440_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _, %C : _, %C2 : _):
   %v1 = llvm.lshr %X, %C
   %v2 = llvm.and %v1, %C2
@@ -3355,7 +3355,7 @@ def alive_InstCombineShift__440_src  (w : Nat)   :=
 
 set_option maxHeartbeats 400000 in
 def alive_InstCombineShift__440_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _, %C : _, %C2 : _):
   %v1 = llvm.shl %C2, %C
   %v2 = llvm.and %X, %v1
@@ -3390,7 +3390,7 @@ theorem alive_InstCombineShift__440  (w : Nat)   : alive_InstCombineShift__440_s
 
 -/
 def alive_InstCombineShift__476_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _, %C : _, %C2 : _):
   %v1 = llvm.lshr %X, %C
   %v2 = llvm.and %v1, %C2
@@ -3401,7 +3401,7 @@ def alive_InstCombineShift__476_src  (w : Nat)   :=
 
 set_option maxHeartbeats 400000 in
 def alive_InstCombineShift__476_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%Y : _, %X : _, %C : _, %C2 : _):
   %v1 = llvm.shl %Y, %C
   %v2 = llvm.shl %C2, %C
@@ -3431,7 +3431,7 @@ theorem alive_InstCombineShift__476  (w : Nat)   : alive_InstCombineShift__476_s
 
 -/
 def alive_InstCombineShift__497_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
   %v1 = llvm.xor %X, %C2
   %v2 = llvm.lshr %v1, %C
@@ -3439,7 +3439,7 @@ def alive_InstCombineShift__497_src  (w : Nat)   :=
 }]
 
 def alive_InstCombineShift__497_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
   %v1 = llvm.lshr %X, %C
   %v2 = llvm.xor %X, %C2
@@ -3466,7 +3466,7 @@ theorem alive_InstCombineShift__497  (w : Nat)   : alive_InstCombineShift__497_s
 
 -/
 def alive_InstCombineShift__497'''_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
   %v1 = llvm.add %X, %C2
   %v2 = llvm.shl %v1, %C
@@ -3474,7 +3474,7 @@ def alive_InstCombineShift__497'''_src  (w : Nat)   :=
 }]
 
 def alive_InstCombineShift__497'''_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _, %C2 : _):
   %v1 = llvm.shl %X, %C
   %v2 = llvm.add %X, %C2
@@ -3500,7 +3500,7 @@ theorem alive_InstCombineShift__497'''  (w : Nat)   : alive_InstCombineShift__49
 
 -/
 def alive_InstCombineShift__582_src  (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _):
   %v1 = llvm.shl %X, %C
   %v2 = llvm.lshr %v1, %C
@@ -3508,7 +3508,7 @@ def alive_InstCombineShift__582_src  (w : Nat)   :=
 }]
 
 def alive_InstCombineShift__582_tgt  (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%X : _, %C : _):
   %v1 = llvm.shl %X, %C
   %v2 = llvm.mlir.constant -1

--- a/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
@@ -29,7 +29,7 @@ precondition: true
 
 -/
 def alive_DivRemOfSelect_src (w : Nat) :=
-  [alive_icom (w)| {
+  [llvm (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
     %c0 = llvm.mlir.constant 0
     %v1 = llvm.select %c, %y, %c0
@@ -38,7 +38,7 @@ def alive_DivRemOfSelect_src (w : Nat) :=
   }]
 
 def alive_DivRemOfSelect_tgt (w : Nat) :=
-  [alive_icom (w)| {
+  [llvm (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
     %v1 = llvm.udiv %x, %y
     llvm.return %v1

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -22,7 +22,7 @@ precondition: true
 %r = udiv %X, %Y
 -/
 def alive_DivRemOfSelect_src (w : Nat) :=
-  [alive_icom (w)| {
+  [llvm (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
     %c0 = llvm.mlir.constant 0
     %v1 = llvm.select %c, %y, %c0
@@ -31,7 +31,7 @@ def alive_DivRemOfSelect_src (w : Nat) :=
   }]
 
 def alive_DivRemOfSelect_tgt (w : Nat) :=
-  [alive_icom (w)| {
+  [llvm (w)| {
   ^bb0(%c: i1, %y : _, %x : _):
     %v1 = llvm.udiv %x, %y
     llvm.return %v1

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -222,18 +222,18 @@ https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Cannot.20F
 Therefore, we choose to match on raw `Expr`.
 -/
 open SSA InstcombineTransformDialect InstCombine in
-elab "[alive_icom (" mvars:term,* ")| " reg:mlir_region "]" : term => do
+elab "[llvm (" mvars:term,* ")| " reg:mlir_region "]" : term => do
   have φ : Nat := mvars.getElems.size
   -- HACK: QQ needs `φ` to be `have`-bound, rather than `let`-bound, otherwise `elabIntoCom` fails
-  let mcom ← withTraceNode `alive_icom (return m!"{exceptEmoji ·} elabIntoCom") <|
+  let mcom ← withTraceNode `llvm (return m!"{exceptEmoji ·} elabIntoCom") <|
     SSA.elabIntoCom reg q(MetaLLVM $φ)
 
   let mvalues : Q(Vector Nat $φ) ←
-    withTraceNode `alive_icom (return m!"{exceptEmoji ·} elaborating mvalues") <| do
+    withTraceNode `llvm (return m!"{exceptEmoji ·} elaborating mvalues") <| do
       let mvalues ← `(⟨[$mvars,*], by rfl⟩)
       elabTermEnsuringType mvalues q(Vector Nat $φ)
 
-  let com ← withTraceNode `alive_icom (return m!"{exceptEmoji ·} building final Expr") <| do
+  let com ← withTraceNode `llvm (return m!"{exceptEmoji ·} building final Expr") <| do
     let instantiateFun ← mkAppM ``MOp.instantiateCom #[mvalues]
     let com ← mkAppM ``Com.changeDialect #[instantiateFun, mcom]
     synthesizeSyntheticMVarsNoPostponing
@@ -241,9 +241,9 @@ elab "[alive_icom (" mvars:term,* ")| " reg:mlir_region "]" : term => do
 
   return com
 
-macro "[alive_icom| " reg:mlir_region "]" : term => `([alive_icom ()| $reg])
+macro "[llvm| " reg:mlir_region "]" : term => `([llvm ()| $reg])
 
 macro "deftest" name:ident " := " test_reg:mlir_region : command => do
   `(@[reducible, llvmTest $name] def $(name) : ConcreteCliTest :=
-       let code := [alive_icom ()| $test_reg]
+       let code := [llvm ()| $test_reg]
        { name := $(quote name.getId), ty := code.ty, context := code.ctxt, code := code, })

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -89,7 +89,7 @@ macro_rules
 section Test
 
 private def pretty_test :=
-  [alive_icom ()|{
+  [llvm ()|{
   ^bb0(%arg0: i32):
     %0 = llvm.mlir.constant 8 : i32
     %1 = llvm.add %0, %arg0 : i32
@@ -99,7 +99,7 @@ private def pretty_test :=
   }]
 
 private def pretty_test_generic (w : Nat) :=
-  [alive_icom (w)|{
+  [llvm (w)|{
   ^bb0(%arg0: _):
     %0 = llvm.mlir.constant 8 : _
     %1 = llvm.add %0, %arg0 : _
@@ -109,7 +109,7 @@ private def pretty_test_generic (w : Nat) :=
   }]
 
 private def prettier_test_generic (w : Nat) :=
-  [alive_icom (w)|{
+  [llvm (w)|{
   ^bb0(%arg0: _):
     %0 = llvm.mlir.constant 8
     %1 = llvm.add %0, %arg0
@@ -119,13 +119,13 @@ private def prettier_test_generic (w : Nat) :=
   }]
 
 private def neg_constant (w : Nat) :=
-  [alive_icom (w)| {
+  [llvm (w)| {
     %0 = llvm.mlir.constant -1
     llvm.return %0
   }]
 
 private def pretty_select (w : Nat) :=
-  [alive_icom (w)| {
+  [llvm (w)| {
     ^bb0(%arg0: i1, %arg1 : _):
       %0 = llvm.select %arg0, %arg1, %arg1
       llvm.return %0

--- a/SSA/Projects/InstCombine/ScalingTest.lean
+++ b/SSA/Projects/InstCombine/ScalingTest.lean
@@ -28,7 +28,7 @@ set_option maxRecDepth 1100
 set_option maxHeartbeats 400000
 
 def and_sequence_10_lhs (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z, %C1
   %v2 = llvm.and %v1, %C1
@@ -44,7 +44,7 @@ def and_sequence_10_lhs (w : Nat)   :=
 }]
 
 def and_sequence_10_rhs (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z,  %C1
   llvm.return %v1
@@ -57,7 +57,7 @@ theorem and_sequence_10_eq (w : Nat) :
   alive_auto
 
 def and_sequence_15_lhs (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z, %C1
   %v2 = llvm.and %v1, %C1
@@ -76,7 +76,7 @@ def and_sequence_15_lhs (w : Nat)   :=
 }]
 
 def and_sequence_15_rhs (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z,  %C1
   llvm.return %v1
@@ -90,7 +90,7 @@ theorem and_sequence_15_eq (w : Nat) :
 
 set_option maxHeartbeats 500000 in
 def and_sequence_20_lhs (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z, %C1
   %v2 = llvm.and %v1, %C1
@@ -116,7 +116,7 @@ def and_sequence_20_lhs (w : Nat)   :=
 }]
 
 def and_sequence_20_rhs (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z,  %C1
   llvm.return %v1
@@ -130,7 +130,7 @@ theorem and_sequence_20_eq (w : Nat) :
 
 set_option maxHeartbeats 1700000 in
 def and_sequence_30_lhs (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z, %C1
   %v2 = llvm.and %v1, %C1
@@ -166,7 +166,7 @@ def and_sequence_30_lhs (w : Nat)   :=
 }]
 
 def and_sequence_30_rhs (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z,  %C1
   llvm.return %v1
@@ -181,7 +181,7 @@ theorem and_sequence_30_eq (w : Nat) :
 set_option maxHeartbeats 3800000 in
 set_option maxRecDepth 1500 in
 def and_sequence_40_lhs (w : Nat)   :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z, %C1
   %v2 = llvm.and %v1, %C1
@@ -227,7 +227,7 @@ def and_sequence_40_lhs (w : Nat)   :=
 }]
 
 def and_sequence_40_rhs (w : Nat)  :=
-[alive_icom ( w )| {
+[llvm ( w )| {
 ^bb0(%C1 : _, %Z : _):
   %v1 = llvm.and %Z,  %C1
   llvm.return %v1

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -195,7 +195,7 @@ info: ⟨[MTy.bitvec (ConcreteOrMVar.concrete 32)],
 theorem com_Γ : com.1 = (Γn 1) := by rfl
 theorem com_ty : com.2.2.1 = .bitvec 32 := by rfl
 
-def bb0IcomConcrete := [alive_icom ()|
+def bb0IcomConcrete := [llvm ()|
 {
   ^bb0(%arg0: i32):
     %0 = llvm.mlir.constant 1 : i32
@@ -207,14 +207,14 @@ def bb0IcomConcrete := [alive_icom ()|
   }]
 
 /-- A simple example of a family of programs, generic over some bitwidth `w` -/
-def GenericWidth (w : Nat) := [alive_icom (w)|
+def GenericWidth (w : Nat) := [llvm (w)|
 {
   ^bb0():
     %0 = llvm.mlir.constant 0
     llvm.return %0
   }]
 
-def bb0IcomGeneric (w : Nat) := [alive_icom (w)|
+def bb0IcomGeneric (w : Nat) := [llvm (w)|
 {
   ^bb0(%arg0: _):
     %0 = llvm.mlir.constant 1
@@ -240,7 +240,7 @@ example (w Γv) : (GenericWidth w).denote Γv = some (BitVec.ofNat w 0) := rfl
 open ComWrappers
 
 def one_inst_macro (w: Nat) :=
-  [alive_icom (w)|{
+  [llvm (w)|{
   ^bb0(%arg0: _):
     %0 = llvm.not %arg0
     llvm.return %0
@@ -271,7 +271,7 @@ def one_inst_macro_proof (w : Nat) :
   apply one_inst_stmt
 
 def two_inst_macro (w: Nat) :=
-  [alive_icom (w)|{
+  [llvm (w)|{
   ^bb0(%arg0: _):
     %0 = llvm.not %arg0
     %1 = llvm.not %arg0
@@ -304,7 +304,7 @@ def two_inst_macro_proof (w : Nat) :
   apply two_inst_stmt
 
 def three_inst_macro (w: Nat) :=
-  [alive_icom (w)|{
+  [llvm (w)|{
   ^bb0(%arg0: _):
     %0 = llvm.not %arg0
     %1 = llvm.not %0
@@ -340,7 +340,7 @@ def three_inst_macro_proof (w : Nat) :
   apply three_inst_stmt
 
 def one_inst_concrete_macro :=
-  [alive_icom ()|{
+  [llvm ()|{
   ^bb0(%arg0: i1):
     %0 = llvm.not %arg0 : i1
     llvm.return %0 : i1
@@ -371,7 +371,7 @@ def one_inst_concrete_macro_proof :
   apply one_inst_concrete_stmt
 
 def two_inst_concrete_macro :=
-  [alive_icom ()|{
+  [llvm ()|{
   ^bb0(%arg0: i1):
     %0 = llvm.not %arg0 : i1
     %1 = llvm.not %arg0 : i1
@@ -404,7 +404,7 @@ def two_inst_concrete_macro_proof :
   apply two_inst_concrete_stmt
 
 def three_inst_concrete_macro :=
-  [alive_icom ()|{
+  [llvm ()|{
   ^bb0(%arg0: i1):
     %0 = llvm.not %arg0 : i1
     %1 = llvm.not %0 : i1
@@ -440,7 +440,7 @@ def three_inst_concrete_macro_proof :
   apply three_inst_concrete_stmt
 
 def two_ne_macro (w : Nat) :=
-  [alive_icom (w)|{
+  [llvm (w)|{
   ^bb0(%arg0: _, %arg1: _):
     %0 = llvm.icmp.ne %arg0,  %arg1
     %1 = llvm.icmp.ne %arg0,  %arg1
@@ -460,7 +460,7 @@ def two_ne_macro_proof (w : Nat) :
   apply two_ne_stmt
 
 def constant_macro (w : Nat) :=
-  [alive_icom (w)|{
+  [llvm (w)|{
   ^bb0():
     %0 = llvm.mlir.constant 2
     %1 = llvm.mlir.constant 1


### PR DESCRIPTION
We mixed alive and llvm and used them overall inconsistently. The llvm dialect syntax really is not specific to alive. Hence, let's rename it to llvm.