### PR TITLE
fix: antiquotations in pretty syntax

### DIFF
--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -536,7 +536,7 @@ syntax "[mlir_attr_val|" mlir_attr_val "]" : term
 syntax "[mlir_attr_val_symbol|" mlir_attr_val_symbol "]" : term
 
 macro_rules
-| `([mlir_attr_val| $$($x) ]) => `($x)
+  | `([mlir_attr_val| $$($x) ]) => `($x)
 
 /-- Convert a possibly negated numeral into a term representing the same value -/
 def negNumToTerm : TSyntax ``neg_num → MacroM Term
@@ -597,9 +597,6 @@ macro_rules
 macro_rules
   | `([mlir_attr_val| # $a:ident]) =>
       `(AttrValue.alias $(Lean.quote a.getId.toString))
-
-macro_rules
-| `([mlir_attr_val| $$($q) ]) => return q
 
 section Test
 

--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -530,6 +530,7 @@ syntax mlir_attr_val_symbol : mlir_attr_val
 syntax neg_num (":" mlir_type)? : mlir_attr_val
 syntax scientificLit (":" mlir_type)? : mlir_attr_val
 syntax ident : mlir_attr_val
+syntax "$" noWs "{" term "}" (":" mlir_type)? : mlir_attr_val
 
 syntax "[" sepBy(mlir_attr_val, ",") "]" : mlir_attr_val
 syntax "[mlir_attr_val|" mlir_attr_val "]" : term
@@ -597,6 +598,13 @@ macro_rules
 macro_rules
   | `([mlir_attr_val| # $a:ident]) =>
       `(AttrValue.alias $(Lean.quote a.getId.toString))
+
+open Elab Term in
+elab_rules : term
+  | `([mlir_attr_val| ${ $x:term }]) => do
+    let x ← elabTerm x none
+    let xTy ← inferType x
+    _
 
 section Test
 

--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -530,7 +530,6 @@ syntax mlir_attr_val_symbol : mlir_attr_val
 syntax neg_num (":" mlir_type)? : mlir_attr_val
 syntax scientificLit (":" mlir_type)? : mlir_attr_val
 syntax ident : mlir_attr_val
-syntax "$" noWs "{" ident "| " term "}" (":" mlir_type)? : mlir_attr_val
 
 syntax "[" sepBy(mlir_attr_val, ",") "]" : mlir_attr_val
 syntax "[mlir_attr_val|" mlir_attr_val "]" : term
@@ -600,14 +599,7 @@ macro_rules
       `(AttrValue.alias $(Lean.quote a.getId.toString))
 
 macro_rules
-  | `([mlir_attr_val| ${$ctor| $x:term } $[: $t]?]) => do
-    let (.ident _ ctorName _ _) := ctor.raw | Macro.throwUnsupported
-    let ctorId := mkIdent <| Name.str ``AttrValue ctorName.toString
-    match ctorName with
-      | "int" | "float" =>
-        let t ← t.getDM `(mlir_type| i32)
-        `($ctorId $x [mlir_type| $t])
-      | _               => `($ctorId $x)
+| `([mlir_attr_val| $$($q) ]) => return q
 
 section Test
 

--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -536,7 +536,7 @@ syntax "[mlir_attr_val|" mlir_attr_val "]" : term
 syntax "[mlir_attr_val_symbol|" mlir_attr_val_symbol "]" : term
 
 macro_rules
-  | `([mlir_attr_val| $$($x) ]) => `($x)
+| `([mlir_attr_val| $$($x) ]) => `($x)
 
 /-- Convert a possibly negated numeral into a term representing the same value -/
 def negNumToTerm : TSyntax ``neg_num → MacroM Term

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -134,4 +134,19 @@ private def pretty_select (w : Nat) :=
 example : pretty_test         = prettier_test_generic 32 := rfl
 example : pretty_test_generic = prettier_test_generic    := rfl
 
+
+/-! ## antiquotations test -/
+
+private def antiquot_test (x) := -- antiquotated constant value in generic syntax
+  [llvm| {
+    %0 = "llvm.mlir.constant"() { value = $(.int (x : Nat) (.i _ 32)) } : () -> (i32)
+    llvm.return %0 : i32
+  }]
+private def antiquot_test_pretty (x : Nat) := -- antiquotated constant value in pretty syntax
+  [llvm| {
+    %0 = llvm.mlir.constant $(x) : i32
+    llvm.return %0 : i32
+  }]
+example : antiquot_test = antiquot_test_pretty := rfl
+
 end Test

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -84,7 +84,7 @@ macro_rules
   | `(mlir_op| $res:mlir_op_operand = llvm.mlir.constant ${ $x:term } $[: $t]?) => do
       let t ← t.getDM `(mlir_type| _)
       let x ← `(MLIR.AST.AttrValue.int $x [mlir_type| $t])
-      `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value =  $$($x) } : () -> ($t) )
+      `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = $$($x) } : () -> ($t) )
 
 syntax mlir_op_operand " = " "llvm.select" mlir_op_operand ", " mlir_op_operand ", " mlir_op_operand
     (" : " mlir_type)? : mlir_op

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -144,8 +144,6 @@ example : pretty_test_generic = prettier_test_generic    := rfl
 
 /-! ## antiquotations test -/
 
-set_option pp.rawOnError true
-
 private def antiquot_test (x) := -- antiquotated constant value in generic syntax
   [llvm| {
     %0 = "llvm.mlir.constant"() { value = $(.int (x : Nat) (.i _ 42)) } : () -> (i42)

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -73,11 +73,14 @@ macro_rules
     let t ← t.getDM `(mlir_type| _)
     `(mlir_op| $resName:mlir_op_operand = $opName ($x, $y) : ($t, $t) -> (i1) )
 
-syntax mlir_op_operand " = " "llvm.mlir.constant" neg_num (" : " mlir_type)? : mlir_op
+syntax mlir_op_operand " = " "llvm.mlir.constant" (neg_num <|> ("$" noWs "{" term "}")) (" : " mlir_type)? : mlir_op
 macro_rules
   | `(mlir_op| $res:mlir_op_operand = llvm.mlir.constant $x $[: $t]?) => do
     let t ← t.getDM `(mlir_type| _)
     `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = $x:neg_num : $t} : () -> ($t) )
+  | `(mlir_op| $res:mlir_op_operand = llvm.mlir.constant ${ $x:term } $[: $t]?) => do
+    let t ← t.getDM `(mlir_type| _)
+    `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = $$(.int $x [mlir_type| $t])} : () -> ($t) )
 
 syntax mlir_op_operand " = " "llvm.select" mlir_op_operand ", " mlir_op_operand ", " mlir_op_operand
     (" : " mlir_type)? : mlir_op
@@ -137,6 +140,8 @@ example : pretty_test_generic = prettier_test_generic    := rfl
 
 /-! ## antiquotations test -/
 
+set_option pp.rawOnError true
+
 private def antiquot_test (x) := -- antiquotated constant value in generic syntax
   [llvm| {
     %0 = "llvm.mlir.constant"() { value = $(.int (x : Nat) (.i _ 32)) } : () -> (i32)
@@ -144,7 +149,7 @@ private def antiquot_test (x) := -- antiquotated constant value in generic synta
   }]
 private def antiquot_test_pretty (x : Nat) := -- antiquotated constant value in pretty syntax
   [llvm| {
-    %0 = llvm.mlir.constant $(x) : i32
+    %0 = llvm.mlir.constant ${x} : i32
     llvm.return %0 : i32
   }]
 example : antiquot_test = antiquot_test_pretty := rfl

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -73,14 +73,15 @@ macro_rules
     let t ← t.getDM `(mlir_type| _)
     `(mlir_op| $resName:mlir_op_operand = $opName ($x, $y) : ($t, $t) -> (i1) )
 
-syntax mlir_op_operand " = " "llvm.mlir.constant" (neg_num <|> ("$" noWs "{" term "}")) (" : " mlir_type)? : mlir_op
+syntax mlir_op_operand " = " "llvm.mlir.constant" neg_num (" : " mlir_type)? : mlir_op
+syntax mlir_op_operand " = " "llvm.mlir.constant" ("$" noWs "{" term "}") (" : " mlir_type)? : mlir_op
 macro_rules
   | `(mlir_op| $res:mlir_op_operand = llvm.mlir.constant $x $[: $t]?) => do
     let t ← t.getDM `(mlir_type| _)
     `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = $x:neg_num : $t} : () -> ($t) )
   | `(mlir_op| $res:mlir_op_operand = llvm.mlir.constant ${ $x:term } $[: $t]?) => do
     let t ← t.getDM `(mlir_type| _)
-    `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = $$(.int $x [mlir_type| $t])} : () -> ($t) )
+    `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = ${int| $x} : $t} : () -> ($t) )
 
 syntax mlir_op_operand " = " "llvm.select" mlir_op_operand ", " mlir_op_operand ", " mlir_op_operand
     (" : " mlir_type)? : mlir_op
@@ -144,13 +145,13 @@ set_option pp.rawOnError true
 
 private def antiquot_test (x) := -- antiquotated constant value in generic syntax
   [llvm| {
-    %0 = "llvm.mlir.constant"() { value = $(.int (x : Nat) (.i _ 32)) } : () -> (i32)
-    llvm.return %0 : i32
+    %0 = "llvm.mlir.constant"() { value = $(.int (x : Nat) (.i _ 42)) } : () -> (i42)
+    llvm.return %0 : i42
   }]
 private def antiquot_test_pretty (x : Nat) := -- antiquotated constant value in pretty syntax
   [llvm| {
-    %0 = llvm.mlir.constant ${x} : i32
-    llvm.return %0 : i32
+    %0 = llvm.mlir.constant ${x} : i42
+    llvm.return %0 : i42
   }]
 example : antiquot_test = antiquot_test_pretty := rfl
 

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -73,15 +73,18 @@ macro_rules
     let t ← t.getDM `(mlir_type| _)
     `(mlir_op| $resName:mlir_op_operand = $opName ($x, $y) : ($t, $t) -> (i1) )
 
+open MLIR.AST
+
 syntax mlir_op_operand " = " "llvm.mlir.constant" neg_num (" : " mlir_type)? : mlir_op
 syntax mlir_op_operand " = " "llvm.mlir.constant" ("$" noWs "{" term "}") (" : " mlir_type)? : mlir_op
 macro_rules
   | `(mlir_op| $res:mlir_op_operand = llvm.mlir.constant $x $[: $t]?) => do
-    let t ← t.getDM `(mlir_type| _)
-    `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = $x:neg_num : $t} : () -> ($t) )
+      let t ← t.getDM `(mlir_type| _)
+      `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = $x:neg_num : $t} : () -> ($t) )
   | `(mlir_op| $res:mlir_op_operand = llvm.mlir.constant ${ $x:term } $[: $t]?) => do
-    let t ← t.getDM `(mlir_type| _)
-    `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value = ${int| $x} : $t} : () -> ($t) )
+      let t ← t.getDM `(mlir_type| _)
+      let x ← `(MLIR.AST.AttrValue.int $x [mlir_type| $t])
+      `(mlir_op| $res:mlir_op_operand = "llvm.mlir.constant"() {value =  $$($x) } : () -> ($t) )
 
 syntax mlir_op_operand " = " "llvm.select" mlir_op_operand ", " mlir_op_operand ", " mlir_op_operand
     (" : " mlir_type)? : mlir_op


### PR DESCRIPTION
Implements pretty quasiquotations for the LLVM dialect, so that we can write:
```lean
$v0 = llvm.mlir.constant ${2**n}
```
where `n` is a Lean variable